### PR TITLE
Fix ForwarderDeposited event data

### DIFF
--- a/contracts/WalletSimple.sol
+++ b/contracts/WalletSimple.sol
@@ -336,7 +336,7 @@ contract WalletSimple {
   function flushForwarderTokens(
     address payable forwarderAddress,
     address tokenContractAddress
-  ) public onlySigner {
+  ) external onlySigner {
     Forwarder forwarder = Forwarder(forwarderAddress);
     forwarder.flushTokens(tokenContractAddress);
   }

--- a/test/batcher.js
+++ b/test/batcher.js
@@ -242,7 +242,7 @@ contract("Batcher", (accounts) => {
         extraValue: 5,
         expectedRetVal: "10",
         expectOverallFailure: true,
-        expectedErrMsg: sendFailedErrorMsg,
+        expectedErrMsg: sendFailedErrorMsg
       };
       await runTestBatcherDriver(params);
     });
@@ -253,7 +253,7 @@ contract("Batcher", (accounts) => {
         values: [5],
         expectedRetVal: "5",
         expectOverallFailure: true,
-        expectedErrMsg: sendFailedErrorMsg,
+        expectedErrMsg: sendFailedErrorMsg
       };
       await runTestBatcherDriver(params);
     });
@@ -331,7 +331,7 @@ contract("Batcher", (accounts) => {
         values: [10, ...createRandIntArr(2)],
         expectedRetVal: "10",
         expectOverallFailure: true,
-        expectedErrMsg: sendFailedErrorMsg,
+        expectedErrMsg: sendFailedErrorMsg
       };
       await runTestBatcherDriver(params);
     });
@@ -344,7 +344,7 @@ contract("Batcher", (accounts) => {
         extraValue: -1,
         expectedRetVal: (randVals[2] - 1).toString(),
         expectOverallFailure: true,
-        expectedErrMsg: sendFailedErrorMsg,
+        expectedErrMsg: sendFailedErrorMsg
       };
       await runTestBatcherDriver(params);
     });
@@ -357,7 +357,7 @@ contract("Batcher", (accounts) => {
         extraValue: -1 * randVals[2],
         expectedRetVal: "0",
         expectOverallFailure: true,
-        expectedErrMsg: sendFailedErrorMsg,
+        expectedErrMsg: sendFailedErrorMsg
       };
       await runTestBatcherDriver(params);
     });
@@ -370,7 +370,7 @@ contract("Batcher", (accounts) => {
         values: randVals,
         extraValue: -1 * (lastTwo - 1),
         expectOverallFailure: true,
-        expectedErrMsg: sendFailedErrorMsg,
+        expectedErrMsg: sendFailedErrorMsg
       };
       await runTestBatcherDriver(params);
     });
@@ -384,7 +384,7 @@ contract("Batcher", (accounts) => {
         extraValue: -1 * lastTwo,
         expectedTransferFailures: [accounts[3], accounts[4]],
         expectOverallFailure: true,
-        expectedErrMsg: sendFailedErrorMsg,
+        expectedErrMsg: sendFailedErrorMsg
       };
       await runTestBatcherDriver(params);
     });
@@ -611,7 +611,7 @@ contract("Batcher", (accounts) => {
           values: [5],
           expectedRetVal: "5",
           expectOverallFailure: true,
-          expectedErrMsg: sendFailedErrorMsg,
+          expectedErrMsg: sendFailedErrorMsg
         };
         await runTestBatcherDriver(params);
 

--- a/test/walletFactory.js
+++ b/test/walletFactory.js
@@ -38,7 +38,7 @@ const createWallet = async (
     ["address[]", "bytes32"],
     [signers, inputSalt]
   );
-  const initCode = getInitCode(util.stripHexPrefix(implementationAddress));
+  const initCode = helpers.getInitCode(util.stripHexPrefix(implementationAddress));
   const walletAddress = helpers.getNextContractAddressCreate2(
     factory.address,
     calculationSalt,
@@ -56,13 +56,6 @@ const createWallet = async (
     JSON.stringify(signers)
   );
   return WalletSimple.at(walletAddress);
-};
-
-const getInitCode = (targetAddress) => {
-  const target = util
-    .stripHexPrefix(targetAddress.toLowerCase())
-    .padStart(40, "0");
-  return `0x3d602d80600a3d3981f3363d3d373d3d3d363d73${target}5af43d82803e903d91602b57fd5bf3`;
 };
 
 contract("WalletFactory", function (accounts) {


### PR DESCRIPTION
The ForwarderDeposited event in the Forwarder.sol contract was always
emitting with the from address set to the forwarder itself. This is not
the desired functionality - it should be set to the actual sender that
sent in to the forwarder in the first place.

For background, DELEGATECALL preserves the correct msg.sender from the
original caller. I.e. if A (sender) CALL -> B (proxy) DELEGATECALL
-> C (implementation), then in C, the msg.sender will be A. However,
CALLs change the msg.sender to the most recent address in the callstack.

In this case, the path looked like:
A (sender) -> B (proxy) -> DELEGATECALL C (implementation receive())
Then the receive() caused B (proxy) -> CALL B (flush()) -> DELEGATECALL
C (flush()). That CALL changes the msg.sender to B instead of A, so our
event emitted by B had itself as the msg.sender.

We fix this issue by pulling the event emission back into the receive()
and fallback() functions themselves.

CLOSES TICKET: BG-28248