### PR TITLE
Remove sending extra funds to sender

### DIFF
--- a/contracts/Batcher.sol
+++ b/contracts/Batcher.sol
@@ -1,5 +1,4 @@
 pragma solidity 0.7.5;
-
 // SPDX-License-Identifier: Apache-2.0
 
 /**
@@ -30,7 +29,7 @@ contract Batcher {
         lockCounter = 1;
         owner = msg.sender;
         emit OwnerChange(address(0), owner);
-        transferGasLimit = 10000;
+        transferGasLimit = 20000;
         emit TransferGasLimitChange(0, transferGasLimit);
     }
 
@@ -49,7 +48,7 @@ contract Batcher {
     /**
      * Transfer funds in a batch to each of recipients
      * @param recipients The list of recipients to send to
-     * @param values The list of values to send to recipients. 
+     * @param values The list of values to send to recipients.
      *  The recipient with index i in recipients array will be sent values[i].
      *  Thus, recipients and values must be the same length
      */
@@ -66,11 +65,6 @@ contract Batcher {
             require(success, "Send failed");
             emit BatchTransfer(msg.sender, recipients[i], values[i]);
         }
-
-        if (address(this).balance > 0) {
-            (bool success,) = msg.sender.call{value: address(this).balance, gas: transferGasLimit}("");
-            require(success, "Sender refund failed");
-        }
     }
 
     /**
@@ -81,7 +75,6 @@ contract Batcher {
      */
     function recover(address to, uint256 value, bytes calldata data) external onlyOwner returns (bytes memory) {
         (bool success, bytes memory returnData) = to.call{value: value}(data);
-        require(success, "Call was not successful");
         return returnData;
     }
 
@@ -96,9 +89,9 @@ contract Batcher {
     }
 
     /**
-     * Change the gas limit that is sent along with batched transfers. 
+     * Change the gas limit that is sent along with batched transfers.
      * This is intended to protect against any EVM level changes that would require
-     * a new amount of gas for an internal send to complete. 
+     * a new amount of gas for an internal send to complete.
      * @param newTransferGasLimit The new gas limit to send along with batched transfers
      */
     function changeTransferGasLimit(uint256 newTransferGasLimit) external onlyOwner {
@@ -110,7 +103,7 @@ contract Batcher {
     fallback() external payable {
         revert("Invalid fallback");
     }
-    
+
     receive() external payable {
         revert("Invalid receive");
     }

--- a/mocha-test/compile.js
+++ b/mocha-test/compile.js
@@ -1,28 +1,28 @@
-const fs = require("fs");
-const { promisify } = require("util");
+const fs = require('fs');
+const { promisify } = require('util');
 
-const _ = require("lodash");
-const should = require("should");
+const _ = require('lodash');
+const should = require('should');
 
-const solc = require("solc");
+const solc = require('solc');
 
 // Useful when async func goes wrong
-process.on("unhandledRejection", (r) => {
-  console.log("UnhandledRejection");
+process.on('unhandledRejection', (r) => {
+  console.log('UnhandledRejection');
   console.error(r);
 });
 
-describe("Contracts", async () => {
+describe('Contracts', async () => {
   const contracts = [
-    "ERC20Interface.sol",
-    "Forwarder.sol",
-    "WalletSimple.sol",
-    "coins/EtcWalletSimple.sol",
-    "coins/RskWalletSimple.sol",
-    "coins/CeloWalletSimple.sol",
-    "WalletFactory.sol",
-    "ForwarderFactory.sol",
-    "CloneFactory.sol"
+    'ERC20Interface.sol',
+    'Forwarder.sol',
+    'WalletSimple.sol',
+    'coins/EtcWalletSimple.sol',
+    'coins/RskWalletSimple.sol',
+    'coins/CeloWalletSimple.sol',
+    'WalletFactory.sol',
+    'ForwarderFactory.sol',
+    'CloneFactory.sol'
   ];
 
   let result;
@@ -32,7 +32,7 @@ describe("Contracts", async () => {
     this.timeout(10000);
     const contents = await Promise.all(
       contracts.map(async (filename) =>
-        (await promisify(fs.readFile)("./contracts/" + filename)).toString()
+        (await promisify(fs.readFile)('./contracts/' + filename)).toString()
       )
     );
 
@@ -44,16 +44,16 @@ describe("Contracts", async () => {
     }
 
     const input = {
-      language: "Solidity",
+      language: 'Solidity',
       sources: {
-        "test.sol": {
-          content: "contract C { function f() public { } }"
+        'test.sol': {
+          content: 'contract C { function f() public { } }'
         }
       },
       settings: {
         outputSelection: {
-          "*": {
-            "*": ["*"]
+          '*': {
+            '*': ['*']
           }
         }
       }
@@ -62,11 +62,11 @@ describe("Contracts", async () => {
     result = solc.compile(JSON.stringify(input));
   });
 
-  it("compile without warnings and errors", () => {
+  it('compile without warnings and errors', () => {
     should.equal(
       (result.errors || []).length,
       0,
-      (result.errors || []).join("\n")
+      (result.errors || []).join('\n')
     );
   });
 });

--- a/test/forwarder.js
+++ b/test/forwarder.js
@@ -1,10 +1,10 @@
-const should = require("should");
+const should = require('should');
 
-const truffleAssert = require("truffle-assertions");
-const helpers = require("./helpers");
-const BigNumber = require("bignumber.js");
+const truffleAssert = require('truffle-assertions');
+const helpers = require('./helpers');
+const BigNumber = require('bignumber.js');
 
-const Forwarder = artifacts.require("./Forwarder.sol");
+const Forwarder = artifacts.require('./Forwarder.sol');
 
 const createForwarder = async (creator, parent) => {
   const forwarderContract = await Forwarder.new([], { from: creator });
@@ -16,13 +16,13 @@ const getBalanceInWei = async (address) => {
   return new BigNumber(await web3.eth.getBalance(address));
 };
 
-const FORWARDER_DEPOSITED_EVENT = "ForwarderDeposited";
+const FORWARDER_DEPOSITED_EVENT = 'ForwarderDeposited';
 
-contract("Forwarder", function (accounts) {
-  it("Basic forwarding test", async function () {
+contract('Forwarder', function (accounts) {
+  it('Basic forwarding test', async function () {
     const forwarder = await createForwarder(accounts[0], accounts[0]);
     const startBalance = await getBalanceInWei(accounts[0]);
-    const amount = web3.utils.toWei("2", "ether");
+    const amount = web3.utils.toWei('2', 'ether');
 
     const tx = await web3.eth.sendTransaction({
       from: accounts[1],
@@ -42,9 +42,9 @@ contract("Forwarder", function (accounts) {
     forwardedEvent.value.should.equal(amount);
   });
 
-  it("Flush on initialization", async function () {
+  it('Flush on initialization', async function () {
     // determine the forwarder contract address
-    const amount = web3.utils.toWei("5", "ether");
+    const amount = web3.utils.toWei('5', 'ether');
     const baseAddress = accounts[3];
     const senderAddress = accounts[0];
     const forwarderAddress = await helpers.getNextContractAddress(
@@ -84,23 +84,23 @@ contract("Forwarder", function (accounts) {
     forwardedEvent.value.should.equal(amount);
   });
 
-  it("Should forward with data passed", async function () {
+  it('Should forward with data passed', async function () {
     const forwarder = await createForwarder(accounts[0], accounts[0]);
     const startBalance = await getBalanceInWei(accounts[0]);
-    const amount = web3.utils.toWei("2", "ether");
+    const amount = web3.utils.toWei('2', 'ether');
 
     await web3.eth.sendTransaction({
       from: accounts[1],
       to: forwarder.address,
       value: amount,
-      data: "0x1234abcd"
+      data: '0x1234abcd'
     });
 
     const endBalance = await getBalanceInWei(accounts[0]);
     startBalance.plus(amount).eq(endBalance).should.be.true();
   });
 
-  it("Should not init twice", async function () {
+  it('Should not init twice', async function () {
     const baseAddress = accounts[3];
     const forwarder = await createForwarder(baseAddress, baseAddress);
 

--- a/test/forwarderFactory.js
+++ b/test/forwarderFactory.js
@@ -1,13 +1,13 @@
-require("should");
+require('should');
 
-const truffleAssert = require("truffle-assertions");
-const helpers = require("./helpers");
-const util = require("ethereumjs-util");
-const abi = require("ethereumjs-abi");
-const BigNumber = require("bignumber.js");
+const truffleAssert = require('truffle-assertions');
+const helpers = require('./helpers');
+const util = require('ethereumjs-util');
+const abi = require('ethereumjs-abi');
+const BigNumber = require('bignumber.js');
 
-const Forwarder = artifacts.require("./Forwarder.sol");
-const ForwarderFactory = artifacts.require("./ForwarderFactory.sol");
+const Forwarder = artifacts.require('./Forwarder.sol');
+const ForwarderFactory = artifacts.require('./ForwarderFactory.sol');
 
 const createForwarderFactory = async () => {
   const forwarderContract = await Forwarder.new([], {});
@@ -32,11 +32,11 @@ const createForwarder = async (
   sender
 ) => {
   const inputSalt = util.setLengthLeft(
-    Buffer.from(util.stripHexPrefix(salt), "hex"),
+    Buffer.from(util.stripHexPrefix(salt), 'hex'),
     32
   );
   const calculationSalt = abi.soliditySHA3(
-    ["address", "bytes32"],
+    ['address', 'bytes32'],
     [parent, inputSalt]
   );
   const initCode = helpers.getInitCode(
@@ -53,12 +53,12 @@ const createForwarder = async (
   return forwarderAddress;
 };
 
-contract("ForwarderFactory", function (accounts) {
-  it("Should create a functional forwarder using the factory", async function () {
+contract('ForwarderFactory', function (accounts) {
+  it('Should create a functional forwarder using the factory', async function () {
     const { factory, implementationAddress } = await createForwarderFactory();
 
     const parent = accounts[0];
-    const salt = "0x1234";
+    const salt = '0x1234';
     const forwarderAddress = await createForwarder(
       factory,
       implementationAddress,
@@ -69,7 +69,7 @@ contract("ForwarderFactory", function (accounts) {
     const startBalance = await getBalanceInWei(parent);
     const startForwarderBalance = await getBalanceInWei(forwarderAddress);
 
-    const amount = web3.utils.toWei("2", "ether");
+    const amount = web3.utils.toWei('2', 'ether');
     await web3.eth.sendTransaction({
       from: accounts[1],
       to: forwarderAddress,
@@ -82,11 +82,11 @@ contract("ForwarderFactory", function (accounts) {
     endForwarderBalance.eq(startForwarderBalance).should.be.true();
   });
 
-  it("Different salt should create at different addresses", async function () {
+  it('Different salt should create at different addresses', async function () {
     const { factory, implementationAddress } = await createForwarderFactory();
 
     const parent = accounts[0];
-    const salt = "0x1234";
+    const salt = '0x1234';
     const forwarderAddress = await createForwarder(
       factory,
       implementationAddress,
@@ -95,7 +95,7 @@ contract("ForwarderFactory", function (accounts) {
       accounts[1]
     );
 
-    const salt2 = "0x12345678";
+    const salt2 = '0x12345678';
     const forwarderAddress2 = await createForwarder(
       factory,
       implementationAddress,
@@ -107,7 +107,7 @@ contract("ForwarderFactory", function (accounts) {
     forwarderAddress.should.not.equal(forwarderAddress2);
   });
 
-  it("Different creators should create at different addresses", async function () {
+  it('Different creators should create at different addresses', async function () {
     const { factory, implementationAddress } = await createForwarderFactory();
     const {
       factory: factory2,
@@ -115,7 +115,7 @@ contract("ForwarderFactory", function (accounts) {
     } = await createForwarderFactory();
 
     const parent = accounts[0];
-    const salt = "0x1234";
+    const salt = '0x1234';
     const forwarderAddress = await createForwarder(
       factory,
       implementationAddress,
@@ -134,11 +134,11 @@ contract("ForwarderFactory", function (accounts) {
     forwarderAddress.should.not.equal(forwarderAddress2);
   });
 
-  it("Different parents should create at different addresses", async function () {
+  it('Different parents should create at different addresses', async function () {
     const { factory, implementationAddress } = await createForwarderFactory();
 
     const parent = accounts[0];
-    const salt = "0x1234";
+    const salt = '0x1234';
     const forwarderAddress = await createForwarder(
       factory,
       implementationAddress,
@@ -159,11 +159,11 @@ contract("ForwarderFactory", function (accounts) {
     forwarderAddress.should.not.equal(forwarderAddress2);
   });
 
-  it("Should fail to create two contracts with the same inputs", async function () {
+  it('Should fail to create two contracts with the same inputs', async function () {
     const { factory, implementationAddress } = await createForwarderFactory();
 
     const parent = accounts[0];
-    const salt = "0x1234";
+    const salt = '0x1234';
     const forwarderAddress = await createForwarder(
       factory,
       implementationAddress,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,11 +1,11 @@
-const abi = require("ethereumjs-abi");
-const util = require("ethereumjs-util");
-const BN = require("bn.js");
-const Promise = require("bluebird");
-const Forwarder = artifacts.require("./Forwarder.sol");
-const ForwarderFactory = artifacts.require("./ForwarderFactory.sol");
-const WalletFactory = artifacts.require("./WalletFactory.sol");
-const WalletSimple = artifacts.require("./WalletSimple.sol");
+const abi = require('ethereumjs-abi');
+const util = require('ethereumjs-util');
+const BN = require('bn.js');
+const Promise = require('bluebird');
+const Forwarder = artifacts.require('./Forwarder.sol');
+const ForwarderFactory = artifacts.require('./ForwarderFactory.sol');
+const WalletFactory = artifacts.require('./WalletFactory.sol');
+const WalletSimple = artifacts.require('./WalletSimple.sol');
 
 const abis = [
   Forwarder.abi,
@@ -19,9 +19,9 @@ exports.showBalances = function () {
   for (let i = 0; i < accounts.length; i++) {
     console.log(
       accounts[i] +
-        ": " +
-        web3.utils.fromWei(web3.eth.getBalance(accounts[i]), "ether"),
-      "ether"
+        ': ' +
+        web3.utils.fromWei(web3.eth.getBalance(accounts[i]), 'ether'),
+      'ether'
     );
   }
 };
@@ -41,7 +41,7 @@ exports.waitForEvents = function (eventsArray, numEvents) {
     }
     if (numTries >= 100) {
       if (eventsArray.length == 0) {
-        console.log("Timed out waiting for events!");
+        console.log('Timed out waiting for events!');
       }
       return;
     }
@@ -60,12 +60,12 @@ exports.getSha3ForConfirmationTx = function (
   sequenceId
 ) {
   return abi.soliditySHA3(
-    ["string", "address", "uint", "bytes", "uint", "uint"],
+    ['string', 'address', 'uint', 'bytes', 'uint', 'uint'],
     [
       prefix,
-      new BN(toAddress.replace("0x", ""), 16),
+      new BN(toAddress.replace('0x', ''), 16),
       amount,
-      Buffer.from(data.replace("0x", ""), "hex"),
+      Buffer.from(data.replace('0x', ''), 'hex'),
       expireTime,
       sequenceId
     ]
@@ -81,7 +81,7 @@ exports.getSha3ForBatchTx = function (
   sequenceId
 ) {
   return abi.soliditySHA3(
-    ["string", "address[]", "uint[]", "uint", "uint"],
+    ['string', 'address[]', 'uint[]', 'uint', 'uint'],
     [prefix, recipients, values, expireTime, sequenceId]
   );
 };
@@ -96,12 +96,12 @@ exports.getSha3ForConfirmationTokenTx = function (
   sequenceId
 ) {
   return abi.soliditySHA3(
-    ["string", "address", "uint", "address", "uint", "uint"],
+    ['string', 'address', 'uint', 'address', 'uint', 'uint'],
     [
       prefix,
-      new BN(toAddress.replace("0x", ""), 16),
+      new BN(toAddress.replace('0x', ''), 16),
       value,
-      new BN(tokenContractAddress.replace("0x", ""), 16),
+      new BN(tokenContractAddress.replace('0x', ''), 16),
       expireTime,
       sequenceId
     ]
@@ -110,7 +110,7 @@ exports.getSha3ForConfirmationTokenTx = function (
 
 // Serialize signature into format understood by our recoverAddress function
 exports.serializeSignature = ({ r, s, v }) =>
-  "0x" + Buffer.concat([r, s, Buffer.from([v])]).toString("hex");
+  '0x' + Buffer.concat([r, s, Buffer.from([v])]).toString('hex');
 
 /**
  * Returns the address a contract will have when created from the provided address
@@ -118,7 +118,7 @@ exports.serializeSignature = ({ r, s, v }) =>
  * @return address
  */
 exports.getNextContractAddress = async (address) => {
-  const addressBuffer = Buffer.from(util.stripHexPrefix(address), "hex");
+  const addressBuffer = Buffer.from(util.stripHexPrefix(address), 'hex');
   const nonce = await web3.eth.getTransactionCount(address);
   return util.toChecksumAddress(
     util.bufferToHex(util.generateAddress(addressBuffer, util.toBuffer(nonce)))
@@ -126,8 +126,8 @@ exports.getNextContractAddress = async (address) => {
 };
 
 exports.getNextContractAddressCreate2 = (address, salt, initCode) => {
-  const addressBuffer = Buffer.from(util.stripHexPrefix(address), "hex");
-  const initCodeBuffer = Buffer.from(util.stripHexPrefix(initCode), "hex");
+  const addressBuffer = Buffer.from(util.stripHexPrefix(address), 'hex');
+  const initCodeBuffer = Buffer.from(util.stripHexPrefix(initCode), 'hex');
   return util.toChecksumAddress(
     util.bufferToHex(util.generateAddress2(addressBuffer, salt, initCodeBuffer))
   );
@@ -138,7 +138,7 @@ exports.assertVMException = async (fn) => {
   try {
     await fn();
   } catch (err) {
-    err.message.toString().should.containEql("VM Exception");
+    err.message.toString().should.containEql('VM Exception');
     failed = true;
   }
 
@@ -148,7 +148,7 @@ exports.assertVMException = async (fn) => {
 exports.getInitCode = (targetAddress) => {
   const target = util
     .stripHexPrefix(targetAddress.toLowerCase())
-    .padStart(40, "0");
+    .padStart(40, '0');
   return `0x3d602d80600a3d3981f3363d3d373d3d3d363d73${target}5af43d82803e903d91602b57fd5bf3`;
 };
 

--- a/test/walletFactory.js
+++ b/test/walletFactory.js
@@ -1,14 +1,14 @@
-require("should");
+require('should');
 
-const truffleAssert = require("truffle-assertions");
-const helpers = require("./helpers");
-const util = require("ethereumjs-util");
-const abi = require("ethereumjs-abi");
-const { privateKeyForAccount } = require("../testrpc/accounts");
-const BigNumber = require("bignumber.js");
+const truffleAssert = require('truffle-assertions');
+const helpers = require('./helpers');
+const util = require('ethereumjs-util');
+const abi = require('ethereumjs-abi');
+const { privateKeyForAccount } = require('../testrpc/accounts');
+const BigNumber = require('bignumber.js');
 
-const WalletSimple = artifacts.require("./WalletSimple.sol");
-const WalletFactory = artifacts.require("./WalletFactory.sol");
+const WalletSimple = artifacts.require('./WalletSimple.sol');
+const WalletFactory = artifacts.require('./WalletFactory.sol');
 
 const createWalletFactory = async () => {
   const walletContract = await WalletSimple.new([], {});
@@ -31,14 +31,16 @@ const createWallet = async (
   sender
 ) => {
   const inputSalt = util.setLengthLeft(
-    Buffer.from(util.stripHexPrefix(salt), "hex"),
+    Buffer.from(util.stripHexPrefix(salt), 'hex'),
     32
   );
   const calculationSalt = abi.soliditySHA3(
-    ["address[]", "bytes32"],
+    ['address[]', 'bytes32'],
     [signers, inputSalt]
   );
-  const initCode = helpers.getInitCode(util.stripHexPrefix(implementationAddress));
+  const initCode = helpers.getInitCode(
+    util.stripHexPrefix(implementationAddress)
+  );
   const walletAddress = helpers.getNextContractAddressCreate2(
     factory.address,
     calculationSalt,
@@ -48,7 +50,7 @@ const createWallet = async (
   const tx = await factory.createWallet(signers, inputSalt, { from: sender });
   const walletCreatedEvent = await helpers.getEventFromTransaction(
     tx.receipt.transactionHash,
-    "WalletCreated"
+    'WalletCreated'
   );
 
   walletCreatedEvent.newWalletAddress.should.equal(walletAddress);
@@ -58,12 +60,12 @@ const createWallet = async (
   return WalletSimple.at(walletAddress);
 };
 
-contract("WalletFactory", function (accounts) {
-  it("Should create a functional wallet using the factory", async function () {
+contract('WalletFactory', function (accounts) {
+  it('Should create a functional wallet using the factory', async function () {
     const { factory, implementationAddress } = await createWalletFactory();
 
     const signers = [accounts[0], accounts[1], accounts[2]];
-    const salt = "0x1234";
+    const salt = '0x1234';
     const wallet = await createWallet(
       factory,
       implementationAddress,
@@ -74,7 +76,7 @@ contract("WalletFactory", function (accounts) {
     const walletAddress = wallet.address;
     const startBalance = await getBalanceInWei(walletAddress);
 
-    const amount = web3.utils.toWei("2", "ether");
+    const amount = web3.utils.toWei('2', 'ether');
     await web3.eth.sendTransaction({
       from: accounts[1],
       to: walletAddress,
@@ -88,10 +90,10 @@ contract("WalletFactory", function (accounts) {
     // Get the operation hash to be signed
     const expireTime = Math.floor(new Date().getTime() / 1000) + 60;
     const operationHash = helpers.getSha3ForConfirmationTx(
-      "ETHER",
+      'ETHER',
       accounts[3].toLowerCase(),
       amount,
-      "0x",
+      '0x',
       expireTime,
       1
     );
@@ -100,7 +102,7 @@ contract("WalletFactory", function (accounts) {
     await wallet.sendMultiSig(
       accounts[3].toLowerCase(),
       amount,
-      "0x",
+      '0x',
       expireTime,
       1,
       helpers.serializeSignature(sig),
@@ -113,11 +115,11 @@ contract("WalletFactory", function (accounts) {
     recipientStartBalance.plus(amount).eq(recipientEndBalance).should.be.true();
   });
 
-  it("Different salt should create at different addresses", async function () {
+  it('Different salt should create at different addresses', async function () {
     const { factory, implementationAddress } = await createWalletFactory();
 
     const signers = [accounts[0], accounts[1], accounts[2]];
-    const salt = "0x1234";
+    const salt = '0x1234';
     const walletAddress = await createWallet(
       factory,
       implementationAddress,
@@ -126,7 +128,7 @@ contract("WalletFactory", function (accounts) {
       accounts[1]
     );
 
-    const salt2 = "0x12345678";
+    const salt2 = '0x12345678';
     const walletAddress2 = await createWallet(
       factory,
       implementationAddress,
@@ -138,7 +140,7 @@ contract("WalletFactory", function (accounts) {
     walletAddress.should.not.equal(walletAddress2);
   });
 
-  it("Different creators should create at different addresses", async function () {
+  it('Different creators should create at different addresses', async function () {
     const { factory, implementationAddress } = await createWalletFactory();
     const {
       factory: factory2,
@@ -146,7 +148,7 @@ contract("WalletFactory", function (accounts) {
     } = await createWalletFactory();
 
     const signers = [accounts[0], accounts[1], accounts[2]];
-    const salt = "0x1234";
+    const salt = '0x1234';
     const walletAddress = await createWallet(
       factory,
       implementationAddress,
@@ -165,11 +167,11 @@ contract("WalletFactory", function (accounts) {
     walletAddress.should.not.equal(walletAddress2);
   });
 
-  it("Different signers should create at different addresses", async function () {
+  it('Different signers should create at different addresses', async function () {
     const { factory, implementationAddress } = await createWalletFactory();
 
     const signers = [accounts[0], accounts[1], accounts[2]];
-    const salt = "0x1234";
+    const salt = '0x1234';
     const walletAddress = await createWallet(
       factory,
       implementationAddress,
@@ -190,11 +192,11 @@ contract("WalletFactory", function (accounts) {
     walletAddress.should.not.equal(walletAddress2);
   });
 
-  it("Should fail to create two contracts with the same inputs", async function () {
+  it('Should fail to create two contracts with the same inputs', async function () {
     const { factory, implementationAddress } = await createWalletFactory();
 
     const signers = [accounts[0], accounts[1], accounts[2]];
-    const salt = "0x1234";
+    const salt = '0x1234';
     const walletAddress = await createWallet(
       factory,
       implementationAddress,

--- a/test/walletsimple.js
+++ b/test/walletsimple.js
@@ -1,34 +1,34 @@
-require("assert");
-const should = require("should");
-const truffleAssert = require("truffle-assertions");
-const BigNumber = require("bignumber.js");
-const Promise = require("bluebird");
-const _ = require("lodash");
+require('assert');
+const should = require('should');
+const truffleAssert = require('truffle-assertions');
+const BigNumber = require('bignumber.js');
+const Promise = require('bluebird');
+const _ = require('lodash');
 
-const helpers = require("./helpers");
-const { privateKeyForAccount } = require("../testrpc/accounts");
+const helpers = require('./helpers');
+const { privateKeyForAccount } = require('../testrpc/accounts');
 
 // Used to build the solidity tightly packed buffer to sha3, ecsign
-const util = require("ethereumjs-util");
-const abi = require("ethereumjs-abi");
-const crypto = require("crypto");
+const util = require('ethereumjs-util');
+const abi = require('ethereumjs-abi');
+const crypto = require('crypto');
 
-const WalletFactory = artifacts.require("./WalletFactory.sol");
-const EthWalletSimple = artifacts.require("./WalletSimple.sol");
-const RskWalletSimple = artifacts.require("./RskWalletSimple.sol");
-const EtcWalletSimple = artifacts.require("./EtcWalletSimple.sol");
-const CeloWalletSimple = artifacts.require("./CeloWalletSimple.sol");
-const Fail = artifacts.require("./Fail.sol");
-const GasGuzzler = artifacts.require("./GasGuzzler.sol");
-const GasHeavy = artifacts.require("./GasHeavy.sol");
-const Forwarder = artifacts.require("./Forwarder.sol");
-const ForwarderTarget = artifacts.require("./ForwarderTarget.sol");
-const ForwarderFactory = artifacts.require("./ForwarderFactory.sol");
-const FixedSupplyToken = artifacts.require("./FixedSupplyToken.sol");
-const Tether = artifacts.require("./TetherToken.sol");
+const WalletFactory = artifacts.require('./WalletFactory.sol');
+const EthWalletSimple = artifacts.require('./WalletSimple.sol');
+const RskWalletSimple = artifacts.require('./RskWalletSimple.sol');
+const EtcWalletSimple = artifacts.require('./EtcWalletSimple.sol');
+const CeloWalletSimple = artifacts.require('./CeloWalletSimple.sol');
+const Fail = artifacts.require('./Fail.sol');
+const GasGuzzler = artifacts.require('./GasGuzzler.sol');
+const GasHeavy = artifacts.require('./GasHeavy.sol');
+const Forwarder = artifacts.require('./Forwarder.sol');
+const ForwarderTarget = artifacts.require('./ForwarderTarget.sol');
+const ForwarderFactory = artifacts.require('./ForwarderFactory.sol');
+const FixedSupplyToken = artifacts.require('./FixedSupplyToken.sol');
+const Tether = artifacts.require('./TetherToken.sol');
 
 const assertVMException = (err, expectedErrMsg) => {
-  err.message.toString().should.containEql("VM Exception");
+  err.message.toString().should.containEql('VM Exception');
   if (expectedErrMsg) {
     err.message.toString().should.containEql(expectedErrMsg);
   }
@@ -38,11 +38,11 @@ const createForwarderFromWallet = async (wallet) => {
   const parent = wallet.address;
   const salt = util.bufferToHex(crypto.randomBytes(20));
   const inputSalt = util.setLengthLeft(
-    Buffer.from(util.stripHexPrefix(salt), "hex"),
+    Buffer.from(util.stripHexPrefix(salt), 'hex'),
     32
   );
   const calculationSalt = abi.soliditySHA3(
-    ["address", "bytes32"],
+    ['address', 'bytes32'],
     [parent, inputSalt]
   );
   const forwarderContract = await Forwarder.new([], {});
@@ -90,31 +90,31 @@ const executeCreateForwarder = async (
 
 const coins = [
   {
-    name: "Eth",
-    nativePrefix: "ETHER",
-    nativeBatchPrefix: "ETHER-Batch",
-    tokenPrefix: "ERC20",
+    name: 'Eth',
+    nativePrefix: 'ETHER',
+    nativeBatchPrefix: 'ETHER-Batch',
+    tokenPrefix: 'ERC20',
     WalletSimple: EthWalletSimple
   },
   {
-    name: "Rsk",
-    nativePrefix: "RSK",
-    nativeBatchPrefix: "RSK-Batch",
-    tokenPrefix: "RSK-ERC20",
+    name: 'Rsk',
+    nativePrefix: 'RSK',
+    nativeBatchPrefix: 'RSK-Batch',
+    tokenPrefix: 'RSK-ERC20',
     WalletSimple: RskWalletSimple
   },
   {
-    name: "Etc",
-    nativePrefix: "ETC",
-    nativeBatchPrefix: "ETC-Batch",
-    tokenPrefix: "ETC-ERC20",
+    name: 'Etc',
+    nativePrefix: 'ETC',
+    nativeBatchPrefix: 'ETC-Batch',
+    tokenPrefix: 'ETC-ERC20',
     WalletSimple: EtcWalletSimple
   },
   {
-    name: "Celo",
-    nativePrefix: "CELO",
-    nativeBatchPrefix: "CELO-Batch",
-    tokenPrefix: "CELO-ERC20",
+    name: 'Celo',
+    nativePrefix: 'CELO',
+    nativeBatchPrefix: 'CELO-Batch',
+    tokenPrefix: 'CELO-ERC20',
     WalletSimple: CeloWalletSimple
   }
 ];
@@ -127,25 +127,27 @@ coins.forEach(
     tokenPrefix,
     WalletSimple
   }) => {
-    const DEPOSITED_EVENT = "Deposited";
-    const FORWARDER_DEPOSITED_EVENT = "ForwarderDeposited";
-    const TRANSACTED_EVENT = "Transacted";
-    const SAFE_MODE_ACTIVATE_EVENT = "SafeModeActivated";
+    const DEPOSITED_EVENT = 'Deposited';
+    const FORWARDER_DEPOSITED_EVENT = 'ForwarderDeposited';
+    const TRANSACTED_EVENT = 'Transacted';
+    const SAFE_MODE_ACTIVATE_EVENT = 'SafeModeActivated';
 
     const createWallet = async (creator, signers) => {
       // OK to be the same for all wallets since we are using a new factory for each
-      const salt = '0x1234'; 
+      const salt = '0x1234';
       const { factory, implementationAddress } = await createWalletFactory();
 
       const inputSalt = util.setLengthLeft(
-        Buffer.from(util.stripHexPrefix(salt), "hex"),
+        Buffer.from(util.stripHexPrefix(salt), 'hex'),
         32
       );
       const calculationSalt = abi.soliditySHA3(
-        ["address[]", "bytes32"],
+        ['address[]', 'bytes32'],
         [signers, inputSalt]
       );
-      const initCode = helpers.getInitCode(util.stripHexPrefix(implementationAddress));
+      const initCode = helpers.getInitCode(
+        util.stripHexPrefix(implementationAddress)
+      );
       const walletAddress = helpers.getNextContractAddressCreate2(
         factory.address,
         calculationSalt,
@@ -177,12 +179,12 @@ coins.forEach(
       // If you want to return the complete array, you have to manually write a function to do that.
       const isSigner = async function getSigners(wallet, signer) {
         const signers = [];
-        let i = 0;
+        const i = 0;
         return await wallet.signers.call(signer);
       };
 
-      describe("Wallet creation", function () {
-        it("2 of 3 multisig wallet", async function () {
+      describe('Wallet creation', function () {
+        it('2 of 3 multisig wallet', async function () {
           const wallet = await createWallet(accounts[0], [
             accounts[0],
             accounts[1],
@@ -210,16 +212,16 @@ coins.forEach(
           isSignerArray[3].should.eql(false);
         });
 
-        it("Not enough signer addresses", async function () {
+        it('Not enough signer addresses', async function () {
           try {
             await createWallet(accounts[0], [accounts[0]]);
-            throw new Error("should not be here");
+            throw new Error('should not be here');
           } catch (e) {
-            e.message.should.not.containEql("should not be here");
+            e.message.should.not.containEql('should not be here');
           }
         });
 
-        it("0 address signer", async function () {
+        it('0 address signer', async function () {
           let threw = false;
           try {
             const walletContract = await WalletSimple.new([], {
@@ -228,17 +230,17 @@ coins.forEach(
             await walletContract.init([
               accounts[1],
               accounts[2],
-              "0x0000000000000000000000000000000000000000"
+              '0x0000000000000000000000000000000000000000'
             ]);
           } catch (e) {
             threw = true;
-            assertVMException(e, "Invalid signer");
+            assertVMException(e, 'Invalid signer');
           }
           threw.should.be.true();
         });
       });
 
-      describe("Deposits", function () {
+      describe('Deposits', function () {
         before(async function () {
           wallet = await createWallet(accounts[0], [
             accounts[0],
@@ -247,11 +249,11 @@ coins.forEach(
           ]);
         });
 
-        it("Should emit event on deposit", async function () {
+        it('Should emit event on deposit', async function () {
           const tx = await web3.eth.sendTransaction({
             from: accounts[0],
             to: wallet.address,
-            value: web3.utils.toWei("20", "ether")
+            value: web3.utils.toWei('20', 'ether')
           });
 
           const depositEvent = await helpers.getEventFromTransaction(
@@ -261,15 +263,15 @@ coins.forEach(
 
           // should.exist(depositEvent);
           depositEvent.from.should.eql(accounts[0]);
-          depositEvent.value.should.eql(web3.utils.toWei("20", "ether"));
+          depositEvent.value.should.eql(web3.utils.toWei('20', 'ether'));
         });
 
-        it("Should emit event with data on deposit", async function () {
+        it('Should emit event with data on deposit', async function () {
           const tx = await web3.eth.sendTransaction({
             from: accounts[0],
             to: wallet.address,
-            value: web3.utils.toWei("30", "ether"),
-            data: "0xabcd"
+            value: web3.utils.toWei('30', 'ether'),
+            data: '0xabcd'
           });
           const depositEvent = await helpers.getEventFromTransaction(
             tx.transactionHash,
@@ -278,8 +280,8 @@ coins.forEach(
 
           should.exist(depositEvent);
           depositEvent.from.should.eql(accounts[0]);
-          depositEvent.value.should.eql(web3.utils.toWei("30", "ether"));
-          depositEvent.data.should.eql("0xabcd");
+          depositEvent.value.should.eql(web3.utils.toWei('30', 'ether'));
+          depositEvent.data.should.eql('0xabcd');
         });
       });
 
@@ -395,7 +397,7 @@ coins.forEach(
 
         assert(params.toAddress);
         assert(params.amount);
-        assert(params.data === "" || params.data);
+        assert(params.data === '' || params.data);
         assert(params.expireTime);
         assert(params.sequenceId);
 
@@ -408,7 +410,7 @@ coins.forEach(
         const operationHash = helpers.getSha3ForConfirmationTx(
           params.prefix || nativePrefix,
           otherSignerArgs.toAddress.toLowerCase(),
-          web3.utils.toWei(otherSignerArgs.amount.toString(), "ether"),
+          web3.utils.toWei(otherSignerArgs.amount.toString(), 'ether'),
           otherSignerArgs.data,
           otherSignerArgs.expireTime,
           otherSignerArgs.sequenceId
@@ -420,7 +422,7 @@ coins.forEach(
 
         await params.wallet.sendMultiSig(
           msgSenderArgs.toAddress.toLowerCase(),
-          web3.utils.toWei(web3.utils.toBN(msgSenderArgs.amount), "ether"),
+          web3.utils.toWei(web3.utils.toBN(msgSenderArgs.amount), 'ether'),
           util.addHexPrefix(msgSenderArgs.data),
           msgSenderArgs.expireTime,
           msgSenderArgs.sequenceId,
@@ -444,7 +446,7 @@ coins.forEach(
         const destinationEndBalance = await web3.eth.getBalance(
           params.toAddress
         );
-        const weiAmount = web3.utils.toWei(params.amount.toString(), "ether");
+        const weiAmount = web3.utils.toWei(params.amount.toString(), 'ether');
         new BigNumber(destinationStartBalance)
           .plus(weiAmount)
           .eq(destinationEndBalance)
@@ -471,7 +473,7 @@ coins.forEach(
 
         try {
           await sendMultiSigTestHelper(params);
-          throw new Error("should not have sent successfully");
+          throw new Error('should not have sent successfully');
         } catch (err) {
           assertVMException(err);
         }
@@ -487,7 +489,7 @@ coins.forEach(
         walletStartBalance.should.eql(walletEndBalance);
       };
 
-      describe("Transaction sending using sendMultiSig", function () {
+      describe('Transaction sending using sendMultiSig', function () {
         before(async function () {
           // Create and fund the wallet
           wallet = await createWallet(accounts[0], [
@@ -495,7 +497,7 @@ coins.forEach(
             accounts[1],
             accounts[2]
           ]);
-          const amount = web3.utils.toWei("200000", "ether");
+          const amount = web3.utils.toWei('200000', 'ether');
           await web3.eth.sendTransaction({
             from: accounts[0],
             to: wallet.address,
@@ -513,12 +515,12 @@ coins.forEach(
           sequenceId = parseInt(sequenceIdString);
         });
 
-        it("Send out 50 ether with sendMultiSig", async function () {
+        it('Send out 50 ether with sendMultiSig', async function () {
           // We are not using the helper here because we want to check the operation hash in events
           const destinationAccount = accounts[5];
-          const amount = web3.utils.toWei("50", "ether");
+          const amount = web3.utils.toWei('50', 'ether');
           const expireTime = Math.floor(new Date().getTime() / 1000) + 60; // 60 seconds
-          const data = "0xabcde35f1234";
+          const data = '0xabcde35f1234';
 
           const destinationStartBalance = await web3.eth.getBalance(
             destinationAccount
@@ -569,23 +571,23 @@ coins.forEach(
           transactedEvent.msgSender.should.eql(accounts[0]);
           transactedEvent.otherSigner.should.eql(accounts[1]);
           transactedEvent.operation.should.eql(
-            util.addHexPrefix(operationHash.toString("hex"))
+            util.addHexPrefix(operationHash.toString('hex'))
           );
           transactedEvent.value.should.eql(amount);
           transactedEvent.toAddress.should.eql(destinationAccount);
           transactedEvent.data.should.eql(data);
         });
 
-        it("Stress test: 20 rounds of sendMultiSig", async function () {
+        it('Stress test: 20 rounds of sendMultiSig', async function () {
           for (let round = 0; round < 20; round++) {
             const destinationAccount = accounts[2];
             const amount = web3.utils.toWei(
               web3.utils.toBN(_.random(1, 9)),
-              "ether"
+              'ether'
             );
             const expireTime = Math.floor(new Date().getTime() / 1000) + 60; // 60 seconds
             const data = util.addHexPrefix(
-              crypto.randomBytes(20).toString("hex")
+              crypto.randomBytes(20).toString('hex')
             );
 
             const operationHash = helpers.getSha3ForConfirmationTx(
@@ -602,15 +604,15 @@ coins.forEach(
             );
 
             console.log(
-              "ExpectSuccess " +
+              'ExpectSuccess ' +
                 round +
-                ": " +
+                ': ' +
                 amount +
-                "ETH, seqId: " +
+                'ETH, seqId: ' +
                 sequenceId +
-                ", operationHash: " +
-                operationHash.toString("hex") +
-                ", sig: " +
+                ', operationHash: ' +
+                operationHash.toString('hex') +
+                ', sig: ' +
                 helpers.serializeSignature(sig)
             );
 
@@ -652,7 +654,7 @@ coins.forEach(
           }
         });
 
-        it("Stress test: 10 rounds of attempting to reuse sequence ids - should fail", async function () {
+        it('Stress test: 10 rounds of attempting to reuse sequence ids - should fail', async function () {
           sequenceId -= 10; // these sequence ids already used
           for (let round = 0; round < 10; round++) {
             const destinationAccount = accounts[2];
@@ -674,15 +676,15 @@ coins.forEach(
             );
 
             console.log(
-              "ExpectFail " +
+              'ExpectFail ' +
                 round +
-                ": " +
+                ': ' +
                 amount +
-                "ETH, seqId: " +
+                'ETH, seqId: ' +
                 sequenceId +
-                ", operationHash: " +
-                operationHash.toString("hex") +
-                ", sig: " +
+                ', operationHash: ' +
+                operationHash.toString('hex') +
+                ', sig: ' +
                 helpers.serializeSignature(sig)
             );
 
@@ -720,7 +722,7 @@ coins.forEach(
           }
         });
 
-        it("Stress test: 20 rounds of confirming in a single tx from an incorrect sender - should fail", async function () {
+        it('Stress test: 20 rounds of confirming in a single tx from an incorrect sender - should fail', async function () {
           const sequenceIdString = await wallet.getNextSequenceId.call();
           sequenceId = parseInt(sequenceIdString);
 
@@ -744,15 +746,15 @@ coins.forEach(
             );
 
             console.log(
-              "ExpectFail " +
+              'ExpectFail ' +
                 round +
-                ": " +
+                ': ' +
                 amount +
-                "ETH, seqId: " +
+                'ETH, seqId: ' +
                 sequenceId +
-                ", operationHash: " +
-                operationHash.toString("hex") +
-                ", sig: " +
+                ', operationHash: ' +
+                operationHash.toString('hex') +
+                ', sig: ' +
                 helpers.serializeSignature(sig)
             );
             const destinationStartBalance = await web3.eth.getBalance(
@@ -772,7 +774,7 @@ coins.forEach(
                 helpers.serializeSignature(sig),
                 { from: accounts[1] }
               );
-              throw new Error("should not be here");
+              throw new Error('should not be here');
             } catch (err) {
               assertVMException(err);
             }
@@ -796,14 +798,14 @@ coins.forEach(
           }
         });
 
-        it("Msg sender changing the amount should fail", async function () {
+        it('Msg sender changing the amount should fail', async function () {
           const params = {
             msgSenderAddress: accounts[0],
             otherSignerAddress: accounts[1],
             wallet: wallet,
             toAddress: accounts[8],
             amount: 15,
-            data: "",
+            data: '',
             expireTime: Math.floor(new Date().getTime() / 1000) + 60,
             sequenceId: sequenceId
           };
@@ -816,14 +818,14 @@ coins.forEach(
           await expectFailSendMultiSig(params);
         });
 
-        it("Msg sender changing the destination account should fail", async function () {
+        it('Msg sender changing the destination account should fail', async function () {
           const params = {
             msgSenderAddress: accounts[1],
             otherSignerAddress: accounts[0],
             wallet: wallet,
             toAddress: accounts[5],
             amount: 25,
-            data: "001122ee",
+            data: '001122ee',
             expireTime: Math.floor(new Date().getTime() / 1000) + 60,
             sequenceId: sequenceId
           };
@@ -836,34 +838,34 @@ coins.forEach(
           await expectFailSendMultiSig(params);
         });
 
-        it("Msg sender changing the data should fail", async function () {
+        it('Msg sender changing the data should fail', async function () {
           const params = {
             msgSenderAddress: accounts[1],
             otherSignerAddress: accounts[2],
             wallet: wallet,
             toAddress: accounts[0],
             amount: 30,
-            data: "abcdef",
+            data: 'abcdef',
             expireTime: Math.floor(new Date().getTime() / 1000) + 60,
             sequenceId: sequenceId
           };
 
           // override with different amount
           params.msgSenderArgs = {
-            data: "12bcde"
+            data: '12bcde'
           };
 
           await expectFailSendMultiSig(params);
         });
 
-        it("Msg sender changing the expire time should fail", async function () {
+        it('Msg sender changing the expire time should fail', async function () {
           const params = {
             msgSenderAddress: accounts[0],
             otherSignerAddress: accounts[1],
             wallet: wallet,
             toAddress: accounts[2],
             amount: 50,
-            data: "abcdef",
+            data: 'abcdef',
             expireTime: Math.floor(new Date().getTime() / 1000) + 60,
             sequenceId: sequenceId
           };
@@ -876,14 +878,14 @@ coins.forEach(
           await expectFailSendMultiSig(params);
         });
 
-        it("Same owner signing twice should fail", async function () {
+        it('Same owner signing twice should fail', async function () {
           const params = {
             msgSenderAddress: accounts[2],
             otherSignerAddress: accounts[2],
             wallet: wallet,
             toAddress: accounts[9],
             amount: 51,
-            data: "abcdef",
+            data: 'abcdef',
             expireTime: Math.floor(new Date().getTime() / 1000) + 60,
             sequenceId: sequenceId
           };
@@ -891,14 +893,14 @@ coins.forEach(
           await expectFailSendMultiSig(params);
         });
 
-        it("Sending from an unauthorized signer (but valid other signature) should fail", async function () {
+        it('Sending from an unauthorized signer (but valid other signature) should fail', async function () {
           const params = {
             msgSenderAddress: accounts[7],
             otherSignerAddress: accounts[2],
             wallet: wallet,
             toAddress: accounts[1],
             amount: 52,
-            data: "",
+            data: '',
             expireTime: Math.floor(new Date().getTime() / 1000) + 60,
             sequenceId: sequenceId
           };
@@ -906,14 +908,14 @@ coins.forEach(
           await expectFailSendMultiSig(params);
         });
 
-        it("Sending from an authorized signer (but unauthorized other signer) should fail", async function () {
+        it('Sending from an authorized signer (but unauthorized other signer) should fail', async function () {
           const params = {
             msgSenderAddress: accounts[0],
             otherSignerAddress: accounts[6],
             wallet: wallet,
             toAddress: accounts[6],
             amount: 53,
-            data: "ab1234",
+            data: 'ab1234',
             expireTime: Math.floor(new Date().getTime() / 1000) + 60,
             sequenceId: sequenceId
           };
@@ -922,14 +924,14 @@ coins.forEach(
         });
 
         let usedSequenceId;
-        it("Sending with expireTime very far out should work", async function () {
+        it('Sending with expireTime very far out should work', async function () {
           const params = {
             msgSenderAddress: accounts[0],
             otherSignerAddress: accounts[1],
             wallet: wallet,
             toAddress: accounts[5],
             amount: 60,
-            data: "",
+            data: '',
             expireTime: Math.floor(new Date().getTime() / 1000) + 60,
             sequenceId: sequenceId
           };
@@ -938,14 +940,14 @@ coins.forEach(
           usedSequenceId = sequenceId;
         });
 
-        it("Sending with expireTime in the past should fail", async function () {
+        it('Sending with expireTime in the past should fail', async function () {
           const params = {
             msgSenderAddress: accounts[0],
             otherSignerAddress: accounts[2],
             wallet: wallet,
             toAddress: accounts[2],
             amount: 55,
-            data: "aa",
+            data: 'aa',
             expireTime: Math.floor(new Date().getTime() / 1000) - 100,
             sequenceId: sequenceId
           };
@@ -953,7 +955,7 @@ coins.forEach(
           await expectFailSendMultiSig(params);
         });
 
-        it("Can send with a sequence ID that is not sequential but higher than previous", async function () {
+        it('Can send with a sequence ID that is not sequential but higher than previous', async function () {
           sequenceId = 1000;
           const params = {
             msgSenderAddress: accounts[1],
@@ -961,7 +963,7 @@ coins.forEach(
             wallet: wallet,
             toAddress: accounts[5],
             amount: 60,
-            data: "abcde35f1230",
+            data: 'abcde35f1230',
             expireTime: Math.floor(new Date().getTime() / 1000) + 60,
             sequenceId: sequenceId
           };
@@ -969,7 +971,7 @@ coins.forEach(
           await expectSuccessfulSendMultiSig(params);
         });
 
-        it("Can not send with a sequence ID that is unused but lower than the previous (not strictly monotonic increase)", async function () {
+        it('Can not send with a sequence ID that is unused but lower than the previous (not strictly monotonic increase)', async function () {
           sequenceId = 200;
           const params = {
             msgSenderAddress: accounts[0],
@@ -977,7 +979,7 @@ coins.forEach(
             wallet: wallet,
             toAddress: accounts[5],
             amount: 61,
-            data: "100135f123",
+            data: '100135f123',
             expireTime: Math.floor(new Date().getTime() / 1000) + 60,
             sequenceId: sequenceId
           };
@@ -985,13 +987,13 @@ coins.forEach(
           await expectFailSendMultiSig(params);
         });
 
-        it("Should fail with an invalid signature", async function () {
+        it('Should fail with an invalid signature', async function () {
           sequenceId = sequenceId + 1;
           const msgSenderAddress = accounts[0];
           const otherSignerAddress = accounts[5];
           const toAddress = accounts[6];
-          const amount = "60";
-          const data = "";
+          const amount = '60';
+          const data = '';
           const expireTime = Math.floor(new Date().getTime() / 1000) + 60;
 
           const destinationStartBalance = await web3.eth.getBalance(toAddress);
@@ -1001,7 +1003,7 @@ coins.forEach(
           const operationHash = helpers.getSha3ForConfirmationTx(
             nativePrefix,
             toAddress.toLowerCase(),
-            web3.utils.toWei(amount, "ether"),
+            web3.utils.toWei(amount, 'ether'),
             data,
             expireTime,
             sequenceId
@@ -1017,19 +1019,19 @@ coins.forEach(
           try {
             await wallet.sendMultiSig(
               toAddress.toLowerCase(),
-              web3.utils.toWei(web3.utils.toBN(amount), "ether"),
-              "0x" + data,
+              web3.utils.toWei(web3.utils.toBN(amount), 'ether'),
+              '0x' + data,
               expireTime,
               sequenceId,
               helpers.serializeSignature(sig),
               { from: msgSenderAddress }
             );
           } catch (e) {
-            assertVMException(e, "Invalid signer");
+            assertVMException(e, 'Invalid signer');
           }
         });
 
-        it("Send with a sequence ID that has been previously used should fail", async function () {
+        it('Send with a sequence ID that has been previously used should fail', async function () {
           sequenceId = usedSequenceId || sequenceId - 1;
           const params = {
             msgSenderAddress: accounts[2],
@@ -1037,7 +1039,7 @@ coins.forEach(
             wallet: wallet,
             toAddress: accounts[5],
             amount: 62,
-            data: "",
+            data: '',
             expireTime: Math.floor(new Date().getTime() / 1000) + 60,
             sequenceId: sequenceId
           };
@@ -1045,7 +1047,7 @@ coins.forEach(
           await expectFailSendMultiSig(params);
         });
 
-        it("Send with a sequence ID that is used many transactions ago (lower than previous 10) should fail", async function () {
+        it('Send with a sequence ID that is used many transactions ago (lower than previous 10) should fail', async function () {
           sequenceId = 1;
           const params = {
             msgSenderAddress: accounts[0],
@@ -1053,7 +1055,7 @@ coins.forEach(
             wallet: wallet,
             toAddress: accounts[5],
             amount: 63,
-            data: "5566abfe",
+            data: '5566abfe',
             expireTime: Math.floor(new Date().getTime() / 1000) + 60,
             sequenceId: sequenceId
           };
@@ -1061,7 +1063,7 @@ coins.forEach(
           await expectFailSendMultiSig(params);
         });
 
-        it("Sign with incorrect operation hash prefix should fail", async function () {
+        it('Sign with incorrect operation hash prefix should fail', async function () {
           sequenceId = 1001;
           const params = {
             msgSenderAddress: accounts[0],
@@ -1069,10 +1071,10 @@ coins.forEach(
             wallet: wallet,
             toAddress: accounts[5],
             amount: 63,
-            data: "5566abfe",
+            data: '5566abfe',
             expireTime: Math.floor(new Date().getTime() / 1000) + 60,
             sequenceId: sequenceId,
-            prefix: "Invalid"
+            prefix: 'Invalid'
           };
 
           await expectFailSendMultiSig(params);
@@ -1101,7 +1103,7 @@ coins.forEach(
             recipient.toLowerCase()
           ),
           otherSignerArgs.values.map((value) =>
-            web3.utils.toWei(value.toString(), "ether")
+            web3.utils.toWei(value.toString(), 'ether')
           ),
           otherSignerArgs.expireTime,
           otherSignerArgs.sequenceId
@@ -1114,7 +1116,7 @@ coins.forEach(
         await params.wallet.sendMultiSigBatch(
           msgSenderArgs.recipients,
           msgSenderArgs.values.map((value) =>
-            web3.utils.toWei(value.toString(), "ether")
+            web3.utils.toWei(value.toString(), 'ether')
           ),
           msgSenderArgs.expireTime,
           msgSenderArgs.sequenceId,
@@ -1134,7 +1136,7 @@ coins.forEach(
             recipientValueMap[recipient] = new BigNumber(0);
           }
           recipientValueMap[recipient] = recipientValueMap[recipient].plus(
-            web3.utils.toWei(params.values[i].toString(), "ether")
+            web3.utils.toWei(params.values[i].toString(), 'ether')
           );
         }
 
@@ -1152,7 +1154,7 @@ coins.forEach(
 
         // Check the post-transaction balances
         const weiValues = params.values.map((value) =>
-          web3.utils.toWei(value.toString(), "ether")
+          web3.utils.toWei(value.toString(), 'ether')
         );
         let totalValue = new BigNumber(0);
         for (const recipient of uniqueRecipients) {
@@ -1192,7 +1194,7 @@ coins.forEach(
 
         try {
           await sendMultiSigBatchTestHelper(params);
-          throw new Error("should not have sent successfully");
+          throw new Error('should not have sent successfully');
         } catch (err) {
           assertVMException(err, expectedErrMsg);
         }
@@ -1212,7 +1214,7 @@ coins.forEach(
         walletStartBalance.should.eql(walletEndBalance);
       };
 
-      describe("Batch Transaction sending using sendMultiSigBatch", function () {
+      describe('Batch Transaction sending using sendMultiSigBatch', function () {
         let gasGuzzlerInstance;
         let failInstance;
         let gasHeavyInstance;
@@ -1224,7 +1226,7 @@ coins.forEach(
             accounts[1],
             accounts[2]
           ]);
-          const amount = web3.utils.toWei("200000", "ether");
+          const amount = web3.utils.toWei('200000', 'ether');
           await web3.eth.sendTransaction({
             from: accounts[0],
             to: wallet.address,
@@ -1245,7 +1247,7 @@ coins.forEach(
           sequenceId = parseInt(sequenceIdString);
         });
 
-        it("Batch to two recipients", async function () {
+        it('Batch to two recipients', async function () {
           const params = {
             msgSenderAddress: accounts[0],
             otherSignerAddress: accounts[1],
@@ -1259,7 +1261,7 @@ coins.forEach(
           await expectSuccessfulSendMultiSigBatch(params);
         });
 
-        it("Batch to ten recipients, all the same", async function () {
+        it('Batch to ten recipients, all the same', async function () {
           const params = {
             msgSenderAddress: accounts[0],
             otherSignerAddress: accounts[1],
@@ -1273,7 +1275,7 @@ coins.forEach(
           await expectSuccessfulSendMultiSigBatch(params);
         });
 
-        it("Batch with sum greater than balance should fail", async function () {
+        it('Batch with sum greater than balance should fail', async function () {
           const walletBalance = await web3.eth.getBalance(accounts[0]);
           const halfBalance = new BigNumber(walletBalance).div(2).toFixed();
 
@@ -1287,10 +1289,10 @@ coins.forEach(
             sequenceId: sequenceId
           };
 
-          await expectFailSendMultiSigBatch(params, "Insufficient funds");
+          await expectFailSendMultiSigBatch(params, 'Insufficient funds');
         });
 
-        it("Sending to 0 recipients should fail", async function () {
+        it('Sending to 0 recipients should fail', async function () {
           const params = {
             msgSenderAddress: accounts[0],
             otherSignerAddress: accounts[1],
@@ -1301,10 +1303,10 @@ coins.forEach(
             sequenceId: sequenceId
           };
 
-          await expectFailSendMultiSigBatch(params, "Not enough recipients");
+          await expectFailSendMultiSigBatch(params, 'Not enough recipients');
         });
 
-        it("Sending with differing number of recipients and values should fail", async function () {
+        it('Sending with differing number of recipients and values should fail', async function () {
           const params = {
             msgSenderAddress: accounts[0],
             otherSignerAddress: accounts[1],
@@ -1317,11 +1319,11 @@ coins.forEach(
 
           await expectFailSendMultiSigBatch(
             params,
-            "Unequal recipients and values"
+            'Unequal recipients and values'
           );
         });
 
-        it("Sending to too many recipients", async function () {
+        it('Sending to too many recipients', async function () {
           const params = {
             msgSenderAddress: accounts[0],
             otherSignerAddress: accounts[1],
@@ -1332,10 +1334,10 @@ coins.forEach(
             sequenceId: sequenceId
           };
 
-          await expectFailSendMultiSigBatch(params, "Too many recipients");
+          await expectFailSendMultiSigBatch(params, 'Too many recipients');
         });
 
-        it("Msg sender changing the amount should fail", async function () {
+        it('Msg sender changing the amount should fail', async function () {
           const params = {
             msgSenderAddress: accounts[0],
             otherSignerAddress: accounts[1],
@@ -1351,10 +1353,10 @@ coins.forEach(
             values: [20]
           };
 
-          await expectFailSendMultiSigBatch(params, "Invalid signer");
+          await expectFailSendMultiSigBatch(params, 'Invalid signer');
         });
 
-        it("Msg sender changing the destination account should fail", async function () {
+        it('Msg sender changing the destination account should fail', async function () {
           const params = {
             msgSenderAddress: accounts[1],
             otherSignerAddress: accounts[0],
@@ -1370,10 +1372,10 @@ coins.forEach(
             recipients: [accounts[6]]
           };
 
-          await expectFailSendMultiSigBatch(params, "Invalid signer");
+          await expectFailSendMultiSigBatch(params, 'Invalid signer');
         });
 
-        it("Msg sender changing the expire time should fail", async function () {
+        it('Msg sender changing the expire time should fail', async function () {
           const params = {
             msgSenderAddress: accounts[0],
             otherSignerAddress: accounts[1],
@@ -1389,10 +1391,10 @@ coins.forEach(
             expireTime: Math.floor(new Date().getTime() / 1000) + 1000
           };
 
-          await expectFailSendMultiSigBatch(params, "Invalid signer");
+          await expectFailSendMultiSigBatch(params, 'Invalid signer');
         });
 
-        it("Same owner signing twice should fail", async function () {
+        it('Same owner signing twice should fail', async function () {
           const params = {
             msgSenderAddress: accounts[2],
             otherSignerAddress: accounts[2],
@@ -1403,10 +1405,10 @@ coins.forEach(
             sequenceId: sequenceId
           };
 
-          await expectFailSendMultiSigBatch(params, "Signers cannot be equal.");
+          await expectFailSendMultiSigBatch(params, 'Signers cannot be equal.');
         });
 
-        it("Sending from an unauthorized signer (but valid other signature) should fail", async function () {
+        it('Sending from an unauthorized signer (but valid other signature) should fail', async function () {
           const params = {
             msgSenderAddress: accounts[7],
             otherSignerAddress: accounts[2],
@@ -1419,11 +1421,11 @@ coins.forEach(
 
           await expectFailSendMultiSigBatch(
             params,
-            "Non-signer in onlySigner method."
+            'Non-signer in onlySigner method.'
           );
         });
 
-        it("Sending from an authorized signer (but unauthorized other signer) should fail", async function () {
+        it('Sending from an authorized signer (but unauthorized other signer) should fail', async function () {
           const params = {
             msgSenderAddress: accounts[0],
             otherSignerAddress: accounts[6],
@@ -1434,11 +1436,11 @@ coins.forEach(
             sequenceId: sequenceId
           };
 
-          await expectFailSendMultiSigBatch(params, "Invalid signer");
+          await expectFailSendMultiSigBatch(params, 'Invalid signer');
         });
 
         let usedSequenceId;
-        it("Sending with expireTime very far out should work", async function () {
+        it('Sending with expireTime very far out should work', async function () {
           const params = {
             msgSenderAddress: accounts[0],
             otherSignerAddress: accounts[1],
@@ -1453,7 +1455,7 @@ coins.forEach(
           usedSequenceId = sequenceId;
         });
 
-        it("Sending with expireTime in the past should fail", async function () {
+        it('Sending with expireTime in the past should fail', async function () {
           const params = {
             msgSenderAddress: accounts[0],
             otherSignerAddress: accounts[2],
@@ -1464,10 +1466,10 @@ coins.forEach(
             sequenceId: sequenceId
           };
 
-          await expectFailSendMultiSigBatch(params, "Transaction expired.");
+          await expectFailSendMultiSigBatch(params, 'Transaction expired.');
         });
 
-        it("Can send with a sequence ID that is not sequential but higher than previous", async function () {
+        it('Can send with a sequence ID that is not sequential but higher than previous', async function () {
           sequenceId = 1000;
           const params = {
             msgSenderAddress: accounts[1],
@@ -1482,7 +1484,7 @@ coins.forEach(
           await expectSuccessfulSendMultiSigBatch(params);
         });
 
-        it("Can not send with a sequence ID that is unused but lower than the previous (not strictly monotonic increase)", async function () {
+        it('Can not send with a sequence ID that is unused but lower than the previous (not strictly monotonic increase)', async function () {
           sequenceId = 200;
           const params = {
             msgSenderAddress: accounts[0],
@@ -1494,10 +1496,10 @@ coins.forEach(
             sequenceId: sequenceId
           };
 
-          await expectFailSendMultiSigBatch(params, "sequenceId is too low");
+          await expectFailSendMultiSigBatch(params, 'sequenceId is too low');
         });
 
-        it("Send with a sequence ID that has been previously used should fail", async function () {
+        it('Send with a sequence ID that has been previously used should fail', async function () {
           sequenceId = usedSequenceId || sequenceId - 1;
           const params = {
             msgSenderAddress: accounts[2],
@@ -1509,10 +1511,10 @@ coins.forEach(
             sequenceId: sequenceId
           };
 
-          await expectFailSendMultiSigBatch(params, "sequenceId is too low");
+          await expectFailSendMultiSigBatch(params, 'sequenceId is too low');
         });
 
-        it("Send with a sequence ID that is used many transactions ago (lower than previous 10) should fail", async function () {
+        it('Send with a sequence ID that is used many transactions ago (lower than previous 10) should fail', async function () {
           sequenceId = 1;
           const params = {
             msgSenderAddress: accounts[0],
@@ -1524,10 +1526,10 @@ coins.forEach(
             sequenceId: sequenceId
           };
 
-          await expectFailSendMultiSigBatch(params, "sequenceId is too low");
+          await expectFailSendMultiSigBatch(params, 'sequenceId is too low');
         });
 
-        it("Sign with incorrect operation hash prefix should fail", async function () {
+        it('Sign with incorrect operation hash prefix should fail', async function () {
           sequenceId = 1001;
           const params = {
             msgSenderAddress: accounts[0],
@@ -1537,13 +1539,13 @@ coins.forEach(
             values: [63],
             expireTime: Math.floor(new Date().getTime() / 1000) + 60,
             sequenceId: sequenceId,
-            prefix: "Invalid"
+            prefix: 'Invalid'
           };
 
-          await expectFailSendMultiSigBatch(params, "Invalid signer");
+          await expectFailSendMultiSigBatch(params, 'Invalid signer');
         });
 
-        it("Fails all transfers when one recipient eats all of the gas", async function () {
+        it('Fails all transfers when one recipient eats all of the gas', async function () {
           sequenceId = 1001;
           const params = {
             msgSenderAddress: accounts[0],
@@ -1555,10 +1557,10 @@ coins.forEach(
             sequenceId: sequenceId
           };
 
-          await expectFailSendMultiSigBatch(params, "Call failed");
+          await expectFailSendMultiSigBatch(params, 'Call failed');
         });
 
-        it("Fails all transfers when one recipient fails", async function () {
+        it('Fails all transfers when one recipient fails', async function () {
           sequenceId = 1001;
           const params = {
             msgSenderAddress: accounts[0],
@@ -1570,10 +1572,10 @@ coins.forEach(
             sequenceId: sequenceId
           };
 
-          await expectFailSendMultiSigBatch(params, "Call failed");
+          await expectFailSendMultiSigBatch(params, 'Call failed');
         });
 
-        it("Doesn't fail if one contract uses a lot of gas but doesn't run out", async function () {
+        it('Doesn\'t fail if one contract uses a lot of gas but doesn\'t run out', async function () {
           sequenceId = 1001;
           const params = {
             msgSenderAddress: accounts[0],
@@ -1585,11 +1587,11 @@ coins.forEach(
             sequenceId: sequenceId
           };
 
-          await expectSuccessfulSendMultiSigBatch(params, "Call failed");
+          await expectSuccessfulSendMultiSigBatch(params, 'Call failed');
         });
       });
 
-      describe("Safe mode", function () {
+      describe('Safe mode', function () {
         before(async function () {
           // Create and fund the wallet
           wallet = await createWallet(accounts[0], [
@@ -1600,11 +1602,11 @@ coins.forEach(
           await web3.eth.sendTransaction({
             from: accounts[0],
             to: wallet.address,
-            value: web3.utils.toWei("50000", "ether")
+            value: web3.utils.toWei('50000', 'ether')
           });
         });
 
-        it("Cannot be activated by unauthorized user", async function () {
+        it('Cannot be activated by unauthorized user', async function () {
           await truffleAssert.reverts(
             wallet.activateSafeMode({ from: accounts[5] })
           );
@@ -1612,7 +1614,7 @@ coins.forEach(
           isSafeMode.should.eql(false);
         });
 
-        it("Can be activated by any authorized signer", async function () {
+        it('Can be activated by any authorized signer', async function () {
           for (let i = 0; i < 3; i++) {
             const wallet = await createWallet(accounts[0], [
               accounts[0],
@@ -1625,7 +1627,7 @@ coins.forEach(
           }
         });
 
-        it("Cannot send transactions to external addresses in safe mode", async function () {
+        it('Cannot send transactions to external addresses in safe mode', async function () {
           let isSafeMode = await wallet.safeMode.call();
           isSafeMode.should.eql(false);
           const tx = await wallet.activateSafeMode.sendTransaction({
@@ -1647,7 +1649,7 @@ coins.forEach(
             wallet: wallet,
             toAddress: accounts[8],
             amount: 22,
-            data: "100135f123",
+            data: '100135f123',
             expireTime: Math.floor(new Date().getTime() / 1000) + 60,
             sequenceId: 10001
           };
@@ -1655,14 +1657,14 @@ coins.forEach(
           await expectFailSendMultiSig(params);
         });
 
-        it("Can send transactions to signer addresses in safe mode", async function () {
+        it('Can send transactions to signer addresses in safe mode', async function () {
           const params = {
             msgSenderAddress: accounts[2],
             otherSignerAddress: accounts[1],
             wallet: wallet,
             toAddress: accounts[0],
             amount: 28,
-            data: "100135f123",
+            data: '100135f123',
             expireTime: Math.floor(new Date().getTime() / 1000) + 60,
             sequenceId: 9000
           };
@@ -1671,27 +1673,27 @@ coins.forEach(
         });
       });
 
-      describe("Forwarder addresses", function () {
+      describe('Forwarder addresses', function () {
         const forwardAbi = [
           {
             constant: false,
             inputs: [],
-            name: "flush",
+            name: 'flush',
             outputs: [],
-            type: "function"
+            type: 'function'
           },
           {
             constant: true,
             inputs: [],
-            name: "destinationAddress",
-            outputs: [{ name: "", type: "address" }],
-            type: "function"
+            name: 'destinationAddress',
+            outputs: [{ name: '', type: 'address' }],
+            type: 'function'
           },
-          { inputs: [], type: "constructor" }
+          { inputs: [], type: 'constructor' }
         ];
         const forwardContract = new web3.eth.Contract(forwardAbi);
 
-        it("Create and forward", async function () {
+        it('Create and forward', async function () {
           const wallet = await createWallet(accounts[0], [
             accounts[0],
             accounts[1],
@@ -1701,25 +1703,25 @@ coins.forEach(
             await createForwarderFromWallet(wallet)
           ).create();
           const forwarderBalance = await web3.eth.getBalance(forwarder.address);
-          web3.utils.fromWei(forwarderBalance, "ether").should.eql("0");
+          web3.utils.fromWei(forwarderBalance, 'ether').should.eql('0');
 
           await web3.eth.sendTransaction({
             from: accounts[1],
             to: forwarder.address,
-            value: web3.utils.toWei("200", "ether")
+            value: web3.utils.toWei('200', 'ether')
           });
 
           // Verify funds forwarded
           const endForwarderBalance = await web3.eth.getBalance(
             forwarder.address
           );
-          web3.utils.fromWei(endForwarderBalance, "ether").should.eql("0");
+          web3.utils.fromWei(endForwarderBalance, 'ether').should.eql('0');
 
           const endWalletBalance = await web3.eth.getBalance(wallet.address);
-          web3.utils.fromWei(endWalletBalance, "ether").should.eql("200");
+          web3.utils.fromWei(endWalletBalance, 'ether').should.eql('200');
         });
 
-        it("Forwards value, not call data", async function () {
+        it('Forwards value, not call data', async function () {
           // When calling a nonexistent method on forwarder, transfer call value to target address and emit event on success.
           // Don't call a method on target contract.
           //
@@ -1749,7 +1751,7 @@ coins.forEach(
 
             // calls without value do not emit deposited event and don't get forwarded
             const tx = await forwarderAsTarget.setData(newData, setDataReturn);
-            (await forwarderTarget.data.call()).toString().should.eql("0");
+            (await forwarderTarget.data.call()).toString().should.eql('0');
 
             const depositedEvent = await helpers.getEventFromTransaction(
               tx.receipt.transactionHash,
@@ -1769,7 +1771,7 @@ coins.forEach(
                 value: 100
               }
             );
-            (await forwarderTarget.data.call()).toString().should.eql("0");
+            (await forwarderTarget.data.call()).toString().should.eql('0');
             const newBalance = await web3.eth.getBalance(
               forwarderTarget.address
             );
@@ -1783,7 +1785,7 @@ coins.forEach(
           }
         });
 
-        it("Multiple forward contracts", async function () {
+        it('Multiple forward contracts', async function () {
           const numForwardAddresses = 10;
           const etherEachSend = 4;
           const wallet = await createWallet(accounts[2], [
@@ -1800,20 +1802,20 @@ coins.forEach(
             await web3.eth.sendTransaction({
               from: accounts[1],
               to: forwarder.address,
-              value: web3.utils.toWei(web3.utils.toBN(etherEachSend), "ether")
+              value: web3.utils.toWei(web3.utils.toBN(etherEachSend), 'ether')
             });
           }
 
           // Verify all the forwarding is complete
           const balance = await web3.eth.getBalance(wallet.address);
           web3.utils
-            .fromWei(balance, "ether")
+            .fromWei(balance, 'ether')
             .should.eql(
               web3.utils.toBN(etherEachSend * numForwardAddresses).toString()
             );
         });
 
-        it("Send before create, then flush", async function () {
+        it('Send before create, then flush', async function () {
           const wallet = await createWallet(accounts[3], [
             accounts[3],
             accounts[4],
@@ -1827,17 +1829,17 @@ coins.forEach(
           await web3.eth.sendTransaction({
             from: accounts[1],
             to: forwarderContractAddress,
-            value: web3.utils.toWei("300", "ether")
+            value: web3.utils.toWei('300', 'ether')
           });
           const forwarderBalance = await web3.eth.getBalance(
             forwarderContractAddress
           );
           web3.utils
-            .fromWei(forwarderBalance, "ether")
+            .fromWei(forwarderBalance, 'ether')
             .should.eql(web3.utils.toBN(300).toString());
           const walletBalance = await web3.eth.getBalance(wallet.address);
           web3.utils
-            .fromWei(walletBalance, "ether")
+            .fromWei(walletBalance, 'ether')
             .should.eql(web3.utils.toBN(0).toString());
 
           const forwarder = await create();
@@ -1848,15 +1850,15 @@ coins.forEach(
             forwarderContractAddress
           );
           web3.utils
-            .fromWei(endForwarderBalance, "ether")
+            .fromWei(endForwarderBalance, 'ether')
             .should.eql(web3.utils.toBN(0).toString());
           const endWalletBalance = await web3.eth.getBalance(wallet.address);
           web3.utils
-            .fromWei(endWalletBalance, "ether")
+            .fromWei(endWalletBalance, 'ether')
             .should.eql(web3.utils.toBN(300).toString());
         });
 
-        it("Flush sent from external account", async function () {
+        it('Flush sent from external account', async function () {
           const wallet = await createWallet(accounts[4], [
             accounts[4],
             accounts[5],
@@ -1870,17 +1872,17 @@ coins.forEach(
           await web3.eth.sendTransaction({
             from: accounts[1],
             to: forwarderContractAddress,
-            value: web3.utils.toWei("300", "ether")
+            value: web3.utils.toWei('300', 'ether')
           });
           const forwarderBalance = await web3.eth.getBalance(
             forwarderContractAddress
           );
           web3.utils
-            .fromWei(forwarderBalance, "ether")
+            .fromWei(forwarderBalance, 'ether')
             .should.eql(web3.utils.toBN(300).toString());
           const walletBalance = await web3.eth.getBalance(wallet.address);
           web3.utils
-            .fromWei(walletBalance, "ether")
+            .fromWei(walletBalance, 'ether')
             .should.eql(web3.utils.toBN(0).toString());
 
           const forwarder = await create();
@@ -1891,16 +1893,16 @@ coins.forEach(
             forwarderContractAddress
           );
           web3.utils
-            .fromWei(endForwarderBalance, "ether")
+            .fromWei(endForwarderBalance, 'ether')
             .should.eql(web3.utils.toBN(0).toString());
           const endWalletBalance = await web3.eth.getBalance(wallet.address);
           web3.utils
-            .fromWei(endWalletBalance, "ether")
+            .fromWei(endWalletBalance, 'ether')
             .should.eql(web3.utils.toBN(300).toString());
         });
       });
 
-      describe("ERC20 token transfers", function () {
+      describe('ERC20 token transfers', function () {
         let fixedSupplyTokenContract;
         let tetherTokenContract;
         before(async function () {
@@ -1916,17 +1918,17 @@ coins.forEach(
           const balance = await fixedSupplyTokenContract.balanceOf.call(
             accounts[0]
           );
-          balance.toString().should.eql("1000000");
-          tetherTokenContract = await Tether.new("1000000", "USDT", "USDT", 6, {
+          balance.toString().should.eql('1000000');
+          tetherTokenContract = await Tether.new('1000000', 'USDT', 'USDT', 6, {
             from: accounts[0]
           });
           const tetherBalance = await tetherTokenContract.balanceOf.call(
             accounts[0]
           );
-          tetherBalance.toString().should.eql("1000000");
+          tetherBalance.toString().should.eql('1000000');
         });
 
-        it("Receive and Send tokens from main wallet contract", async function () {
+        it('Receive and Send tokens from main wallet contract', async function () {
           await fixedSupplyTokenContract.transfer(wallet.address, 100, {
             from: accounts[0]
           });
@@ -1993,7 +1995,7 @@ coins.forEach(
             .should.be.true();
         });
 
-        it("Flush from Forwarder contract", async function () {
+        it('Flush from Forwarder contract', async function () {
           const forwarder = await (
             await createForwarderFromWallet(wallet)
           ).create();
@@ -2036,16 +2038,14 @@ coins.forEach(
            */
         });
 
-        it("Flush Tether from Forwarder contract", async function () {
+        it('Flush Tether from Forwarder contract', async function () {
           const forwarder = await (
             await createForwarderFromWallet(wallet)
           ).create();
           await tetherTokenContract.transfer(forwarder.address, 100, {
             from: accounts[0]
           });
-          const balance = await tetherTokenContract.balanceOf.call(
-            accounts[0]
-          );
+          const balance = await tetherTokenContract.balanceOf.call(accounts[0]);
           balance.should.eql(web3.utils.toBN(1000000 - 100));
 
           const forwarderContractStartTokens = await tetherTokenContract.balanceOf.call(

--- a/testrpc/accounts.js
+++ b/testrpc/accounts.js
@@ -1,18 +1,18 @@
-const util = require("ethereumjs-util");
+const util = require('ethereumjs-util');
 
 exports.accounts = [
-  "0xc8209c2200f920b11a460733c91687565c712b40c6f0350e9ad4138bf3193e47",
-  "0x915334f048736c64127e91a1dc35dad86c91e59081cdc12cd060103050e2f3b1",
-  "0x80bf357dd53e61db0e68acbb270e16fd42645903b51329c856cf3cb36f180a3e",
-  "0xdf231d240ce40f844d56cea3a7663b4be8c373fdd6a4fe69cacaaa68c698c590",
-  "0x71ce3f6c92d687ebbdc9b632744178707f39228ae1001a2de66f8b98de36ca07",
-  "0xca4e687f97b8c64705cddb53c92454994c83abcb4218c7c62955bac292c3bc9e",
-  "0x0755057fc0113fdc174e919622f237d30044a4c1c47f3663608b9ee9e8a1a58a",
-  "0x1a4002a3e2d0c18c058265600838cff40ba24303f6e60cd1c74821e8251f84d5",
-  "0x6d276292b8f5047b54db5b2179b5f7050636feaccf6c97a2978200d41d9d3374",
-  "0xace7201611ba195f85fb2e25b53e0f9869e57e2267d1c5eef63144c75dee5142"
+  '0xc8209c2200f920b11a460733c91687565c712b40c6f0350e9ad4138bf3193e47',
+  '0x915334f048736c64127e91a1dc35dad86c91e59081cdc12cd060103050e2f3b1',
+  '0x80bf357dd53e61db0e68acbb270e16fd42645903b51329c856cf3cb36f180a3e',
+  '0xdf231d240ce40f844d56cea3a7663b4be8c373fdd6a4fe69cacaaa68c698c590',
+  '0x71ce3f6c92d687ebbdc9b632744178707f39228ae1001a2de66f8b98de36ca07',
+  '0xca4e687f97b8c64705cddb53c92454994c83abcb4218c7c62955bac292c3bc9e',
+  '0x0755057fc0113fdc174e919622f237d30044a4c1c47f3663608b9ee9e8a1a58a',
+  '0x1a4002a3e2d0c18c058265600838cff40ba24303f6e60cd1c74821e8251f84d5',
+  '0x6d276292b8f5047b54db5b2179b5f7050636feaccf6c97a2978200d41d9d3374',
+  '0xace7201611ba195f85fb2e25b53e0f9869e57e2267d1c5eef63144c75dee5142'
 ].map((privkeyHex) => {
-  const privkey = Buffer.from(privkeyHex.replace(/^0x/i, ""), "hex");
+  const privkey = Buffer.from(privkeyHex.replace(/^0x/i, ''), 'hex');
   const pubkey = util.privateToPublic(privkey);
   const address = util.pubToAddress(pubkey);
   return { privkey, pubkey, address };
@@ -20,14 +20,14 @@ exports.accounts = [
 
 const mapAddrToAcct = exports.accounts.reduce(
   (obj, { address, privkey }) =>
-    Object.assign(obj, { [address.toString("hex")]: privkey }),
+    Object.assign(obj, { [address.toString('hex')]: privkey }),
   {}
 );
 
 exports.privateKeyForAccount = (acct) => {
   const result = mapAddrToAcct[util.stripHexPrefix(acct).toLowerCase()];
   if (!result) {
-    throw new Error("no privkey for " + acct);
+    throw new Error('no privkey for ' + acct);
   }
   return result;
 };

--- a/testrpc/run.js
+++ b/testrpc/run.js
@@ -1,17 +1,17 @@
 #!/bin/env node
 
-const TestRPC = require("ganache-cli");
+const TestRPC = require('ganache-cli');
 
-const accounts = require("./accounts");
+const accounts = require('./accounts');
 
-const defaultBalance = "200000000000000000000000000";
+const defaultBalance = '200000000000000000000000000';
 
-const defaultPort = "8545";
+const defaultPort = '8545';
 const defaultHostname = undefined;
 
 const options = {
   accounts: accounts.accounts.map(({ privkey }) => ({
-    secretKey: "0x" + privkey.toString("hex"),
+    secretKey: '0x' + privkey.toString('hex'),
     balance: defaultBalance
   }))
 };


### PR DESCRIPTION
Remove sending back stuck funds in batcher

Currently, sending extra funds to batcher will send all funds that are
in the batcher contract to msg.sender. We replace this action by
letting an admin call the recover function to remove stuck funds.
This is done to prevent someone from front running a transaction
that leaves ETH in the contract and calling batch() right after to
withdraw the contract balance.

CLOSES Ticket: BG-28164
