### PR TITLE
Fix Batcher Comment

### DIFF
--- a/contracts/Batcher.sol
+++ b/contracts/Batcher.sol
@@ -11,9 +11,8 @@ pragma solidity 0.7.5;
  * funnel off those funds to the correct accounts in a single transaction. This is useful for saving on gas when a
  * bunch of funds need to be transferred to different accounts.
  *
- * This contract will return any excess funds in a batch back to the sender. It should never store any ETH on it.
+ * If more ETH is sent to `batch` than it is instructed to transfer, contact the contract owner in order to recover the excess.
  * If any tokens are accidentally transferred to this account, contact the contract owner in order to recover them.
- *
  *
  */
 


### PR DESCRIPTION
This commit fixes the contract comment for batcher to correctly specify
that any excess ETH sent to the contract will remain stuck.

This is in response to smart contract audit request L-3.3.1