### PR TITLE
Read sequence id array from memory

### DIFF
--- a/test/gas.js
+++ b/test/gas.js
@@ -50,6 +50,10 @@ const createAndGetWallet = async (creator, signers) => {
 
 const checkGasUsed = (expected, actual) => {
     const diff = Math.abs(actual - expected);
+    if (diff >= GAS_DIFF_THRESHOLD) {
+        // log so the user knows the values
+        console.log(`Gas differs from expected. Expected: ${expected}, Actual: ${actual}`);
+    }
     diff.should.be.lessThan(GAS_DIFF_THRESHOLD);
 }
 
@@ -112,7 +116,7 @@ contract(`Wallet Operations Gas Usage`, function (accounts) {
             .eq(destinationEndBalance)
             .should.be.true();
 
-        checkGasUsed(92330, transaction.receipt.gasUsed);
+        checkGasUsed(75886, transaction.receipt.gasUsed);
     });
 
     const sendBatchHelper = async (batchSize) => {
@@ -173,7 +177,7 @@ contract(`Wallet Operations Gas Usage`, function (accounts) {
     };
 
     it('WalletSimple send batch', async function () {
-        const gasUsageByBatchSize = [94530, 104641, 114763, 124873, 134959, 145094, 155205, 165303, 175425, 185524];
+        const gasUsageByBatchSize = [78060, 88194, 98316, 108427, 118537, 128648, 138747, 148869, 158980, 169079];
 
         for (let batchSize = 1; batchSize <= 10; batchSize++) {
             const transaction = await sendBatchHelper(batchSize);


### PR DESCRIPTION
Sload is a very expensive operation in ethereum - it costs 800 gas each
time. In the tryInsertSequenceId function we perform many sloads to
fetch the values of sequence ids at different locations in the array.
This commit improves the gas utilization of this function by only
fetching the values from storage one time, reading them from memory
after that.

CLOSES TICKET: BG-30046