### PR TITLE
Add Tether test for WalletSimple

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -287,6 +287,116 @@
         "fastq": "^1.6.0"
       }
     },
+    "@resolver-engine/core": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/core/-/core-0.2.1.tgz",
+      "integrity": "sha512-nsLQHmPJ77QuifqsIvqjaF5B9aHnDzJjp73Q1z6apY3e9nqYrx4Dtowhpsf7Jwftg/XzVDEMQC+OzUBNTS+S1A==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.1.0",
+        "request": "^2.85.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
+    "@resolver-engine/fs": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/fs/-/fs-0.2.1.tgz",
+      "integrity": "sha512-7kJInM1Qo2LJcKyDhuYzh9ZWd+mal/fynfL9BNjWOiTcOpX+jNfqb/UmGUqros5pceBITlWGqS4lU709yHFUbg==",
+      "dev": true,
+      "requires": {
+        "@resolver-engine/core": "^0.2.1",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
+    "@resolver-engine/imports": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/imports/-/imports-0.2.2.tgz",
+      "integrity": "sha512-u5/HUkvo8q34AA+hnxxqqXGfby5swnH0Myw91o3Sm2TETJlNKXibFGSKBavAH+wvWdBi4Z5gS2Odu0PowgVOUg==",
+      "dev": true,
+      "requires": {
+        "@resolver-engine/core": "^0.2.1",
+        "debug": "^3.1.0",
+        "hosted-git-info": "^2.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
+    "@resolver-engine/imports-fs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/imports-fs/-/imports-fs-0.2.2.tgz",
+      "integrity": "sha512-gFCgMvCwyppjwq0UzIjde/WI+yDs3oatJhozG9xdjJdewwtd7LiF0T5i9lrHAUtqrQbqoFE4E+ZMRVHWpWHpKQ==",
+      "dev": true,
+      "requires": {
+        "@resolver-engine/fs": "^0.2.1",
+        "@resolver-engine/imports": "^0.2.2",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -2372,16 +2482,40 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "ganache-cli": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.10.1.tgz",
-      "integrity": "sha512-3lpBxILtJBxkNVo+U8ad2qbkzB6nZ53gXhXH6NiS0Pauqur86rGbhXz6fNASjBosZm9iJ8Nr71fJd331QODFkQ==",
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.12.2.tgz",
+      "integrity": "sha512-bnmwnJDBDsOWBUP8E/BExWf85TsdDEFelQSzihSJm9VChVO1SHp94YXLP5BlA4j/OTxp0wR4R1Tje9OHOuAJVw==",
       "requires": {
-        "ethereumjs-util": "6.1.0",
-        "scrypt": "6.0.3",
+        "ethereumjs-util": "6.2.1",
         "source-map-support": "0.5.12",
         "yargs": "13.2.4"
       },
       "dependencies": {
+        "@types/bn.js": {
+          "version": "4.11.6",
+          "bundled": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/node": {
+          "version": "14.11.2",
+          "bundled": true
+        },
+        "@types/pbkdf2": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/secp256k1": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
         "ansi-regex": {
           "version": "4.1.0",
           "bundled": true
@@ -2393,19 +2527,16 @@
             "color-convert": "^1.9.0"
           }
         },
-        "bindings": {
-          "version": "1.5.0",
-          "bundled": true,
-          "requires": {
-            "file-uri-to-path": "1.0.0"
-          }
-        },
-        "bip66": {
-          "version": "1.1.5",
+        "base-x": {
+          "version": "3.0.8",
           "bundled": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
+        },
+        "blakejs": {
+          "version": "1.1.0",
+          "bundled": true
         },
         "bn.js": {
           "version": "4.11.9",
@@ -2425,6 +2556,22 @@
             "evp_bytestokey": "^1.0.3",
             "inherits": "^2.0.1",
             "safe-buffer": "^5.0.1"
+          }
+        },
+        "bs58": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "base-x": "^3.0.2"
+          }
+        },
+        "bs58check": {
+          "version": "2.1.2",
+          "bundled": true,
+          "requires": {
+            "bs58": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "safe-buffer": "^5.1.2"
           }
         },
         "buffer-from": {
@@ -2505,15 +2652,6 @@
           "version": "1.2.0",
           "bundled": true
         },
-        "drbg.js": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "browserify-aes": "^1.0.6",
-            "create-hash": "^1.1.2",
-            "create-hmac": "^1.1.4"
-          }
-        },
         "elliptic": {
           "version": "6.5.3",
           "bundled": true,
@@ -2538,17 +2676,38 @@
             "once": "^1.4.0"
           }
         },
-        "ethereumjs-util": {
-          "version": "6.1.0",
+        "ethereum-cryptography": {
+          "version": "0.1.3",
           "bundled": true,
           "requires": {
+            "@types/pbkdf2": "^3.0.0",
+            "@types/secp256k1": "^4.0.1",
+            "blakejs": "^1.1.0",
+            "browserify-aes": "^1.2.0",
+            "bs58check": "^2.1.2",
+            "create-hash": "^1.2.0",
+            "create-hmac": "^1.1.7",
+            "hash.js": "^1.1.7",
+            "keccak": "^3.0.0",
+            "pbkdf2": "^3.0.17",
+            "randombytes": "^2.1.0",
+            "safe-buffer": "^5.1.2",
+            "scrypt-js": "^3.0.0",
+            "secp256k1": "^4.0.1",
+            "setimmediate": "^1.0.5"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "6.2.1",
+          "bundled": true,
+          "requires": {
+            "@types/bn.js": "^4.11.3",
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "0.1.6",
-            "keccak": "^1.0.2",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1",
-            "secp256k1": "^3.0.1"
+            "rlp": "^2.2.3"
           }
         },
         "ethjs-util": {
@@ -2579,10 +2738,6 @@
             "signal-exit": "^3.0.0",
             "strip-eof": "^1.0.0"
           }
-        },
-        "file-uri-to-path": {
-          "version": "1.0.0",
-          "bundled": true
         },
         "find-up": {
           "version": "3.0.0",
@@ -2653,13 +2808,11 @@
           "bundled": true
         },
         "keccak": {
-          "version": "1.4.0",
+          "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "bindings": "^1.2.1",
-            "inherits": "^2.0.3",
-            "nan": "^2.2.1",
-            "safe-buffer": "^5.1.0"
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
           }
         },
         "lcid": {
@@ -2714,12 +2867,16 @@
           "version": "1.0.1",
           "bundled": true
         },
-        "nan": {
-          "version": "2.14.1",
-          "bundled": true
-        },
         "nice-try": {
           "version": "1.0.5",
+          "bundled": true
+        },
+        "node-addon-api": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "node-gyp-build": {
+          "version": "4.2.3",
           "bundled": true
         },
         "npm-run-path": {
@@ -2783,12 +2940,30 @@
           "version": "2.0.1",
           "bundled": true
         },
+        "pbkdf2": {
+          "version": "3.1.1",
+          "bundled": true,
+          "requires": {
+            "create-hash": "^1.1.2",
+            "create-hmac": "^1.1.4",
+            "ripemd160": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
+          }
+        },
         "pump": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
+          }
+        },
+        "randombytes": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.0"
           }
         },
         "readable-stream": {
@@ -2827,18 +3002,17 @@
           "version": "5.2.1",
           "bundled": true
         },
+        "scrypt-js": {
+          "version": "3.0.1",
+          "bundled": true
+        },
         "secp256k1": {
-          "version": "3.8.0",
+          "version": "4.0.2",
           "bundled": true,
           "requires": {
-            "bindings": "^1.5.0",
-            "bip66": "^1.1.5",
-            "bn.js": "^4.11.8",
-            "create-hash": "^1.2.0",
-            "drbg.js": "^1.0.1",
             "elliptic": "^6.5.2",
-            "nan": "^2.14.0",
-            "safe-buffer": "^5.1.2"
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
           }
         },
         "semver": {
@@ -2847,6 +3021,10 @@
         },
         "set-blocking": {
           "version": "2.0.0",
+          "bundled": true
+        },
+        "setimmediate": {
+          "version": "1.0.5",
           "bundled": true
         },
         "sha.js": {
@@ -3238,6 +3416,12 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
+    },
+    "hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
     },
     "http-cache-semantics": {
       "version": "4.1.0",
@@ -4051,12 +4235,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
-    },
-    "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-      "optional": true
     },
     "nano-json-stream-parser": {
       "version": "0.1.2",
@@ -4898,15 +5076,6 @@
             "has-flag": "^1.0.0"
           }
         }
-      }
-    },
-    "scrypt": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
-      "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
-      "optional": true,
-      "requires": {
-        "nan": "^2.0.8"
       }
     },
     "scrypt-js": {
@@ -6501,10 +6670,92 @@
         "lodash.isequal": "^4.5.0"
       }
     },
+    "truffle-flattener": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.5.0.tgz",
+      "integrity": "sha512-vmzWG/L5OXoNruMV6u2l2IaheI091e+t+fFCOR9sl46EE3epkSRIwGCmIP/EYDtPsFBIG7e6exttC9/GlfmxEQ==",
+      "dev": true,
+      "requires": {
+        "@resolver-engine/imports-fs": "^0.2.2",
+        "@solidity-parser/parser": "^0.8.0",
+        "find-up": "^2.1.0",
+        "mkdirp": "^1.0.4",
+        "tsort": "0.0.1"
+      },
+      "dependencies": {
+        "@solidity-parser/parser": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.8.2.tgz",
+          "integrity": "sha512-8LySx3qrNXPgB5JiULfG10O3V7QTxI/TLzSw5hFQhXWSkVxZBAv4rZQ0sYgLEbc8g3L2lmnujj1hKul38Eu5NQ==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
     "tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
       "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+    },
+    "tsort": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tsort/-/tsort-0.0.1.tgz",
+      "integrity": "sha1-4igPXoF/i/QnVlf9D5rr1E9aJ4Y=",
+      "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bn.js": "^4.11.3",
     "ethereumjs-abi": "^0.6.8",
     "ethereumjs-util": "^7.0.4",
-    "ganache-cli": "^6.10.1",
+    "ganache-cli": "^6.12.2",
     "lodash": "^4.12.0",
     "mocha": "^4.1.0",
     "q": "^1.5.1",
@@ -46,6 +46,7 @@
     "prettier": "^2.1.2",
     "prettier-plugin-solidity": "^1.0.0-alpha.58",
     "solhint-plugin-prettier": "0.0.5",
-    "solidity-coverage": "^0.7.15"
+    "solidity-coverage": "^0.7.15",
+    "truffle-flattener": "^1.5.0"
   }
 }


### PR DESCRIPTION
This PR bumps the ganache-cli version to work with node-14, adds truffle-flatener for easy contract deploys using remix, and adds a new Tether test for wallet simple.