### PR TITLE
chore: remove uniswap library

### DIFF
--- a/contracts/Forwarder.sol
+++ b/contracts/Forwarder.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8;
-import '@uniswap/lib/contracts/libraries/TransferHelper.sol';
 import '@openzeppelin/contracts/token/ERC1155/IERC1155.sol';
 import '@openzeppelin/contracts/token/ERC721/IERC721.sol';
 import '@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol';
 import '@openzeppelin/contracts/token/ERC1155/utils/ERC1155Receiver.sol';
 import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 import './ERC20Interface.sol';
+import './TransferHelper.sol';
 
 /**
  * Contract that will forward any incoming Ether to the creator of the contract

--- a/contracts/TransferHelper.sol
+++ b/contracts/TransferHelper.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// source: https://github.com/Uniswap/solidity-lib/blob/master/contracts/libraries/TransferHelper.sol
+pragma solidity 0.8;
+
+// helper methods for interacting with ERC20 tokens and sending ETH that do not consistently return true/false
+library TransferHelper {
+  function safeTransfer(
+    address token,
+    address to,
+    uint256 value
+  ) internal {
+    // bytes4(keccak256(bytes('transfer(address,uint256)')));
+    (bool success, bytes memory data) = token.call(
+      abi.encodeWithSelector(0xa9059cbb, to, value)
+    );
+    require(
+      success && (data.length == 0 || abi.decode(data, (bool))),
+      'TransferHelper::safeTransfer: transfer failed'
+    );
+  }
+
+  function safeTransferFrom(
+    address token,
+    address from,
+    address to,
+    uint256 value
+  ) internal {
+    // bytes4(keccak256(bytes('transferFrom(address,address,uint256)')));
+    (bool success, bytes memory data) = token.call(
+      abi.encodeWithSelector(0x23b872dd, from, to, value)
+    );
+    require(
+      success && (data.length == 0 || abi.decode(data, (bool))),
+      'TransferHelper::transferFrom: transferFrom failed'
+    );
+  }
+}

--- a/contracts/WalletSimple.sol
+++ b/contracts/WalletSimple.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8;
-import '@uniswap/lib/contracts/libraries/TransferHelper.sol';
+import './TransferHelper.sol';
 import './Forwarder.sol';
 import './ERC20Interface.sol';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@openzeppelin/contracts": "4.4.1",
-        "@uniswap/lib": "^4.0.1-alpha",
         "bignumber.js": "^9.0.0",
         "bluebird": "^3.3.5",
         "bn": "^1.0.1",
@@ -6245,14 +6244,6 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@uniswap/lib": {
-      "version": "4.0.1-alpha",
-      "resolved": "https://registry.npmjs.org/@uniswap/lib/-/lib-4.0.1-alpha.tgz",
-      "integrity": "sha512-f6UIliwBbRsgVLxIaBANF6w09tYqc6Y/qXdsrbEmXHyFA7ILiKrIwRFXe1yOg8M3cksgVsO9N7yuL2DdCGQKBA==",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@wry/context": {
@@ -32282,11 +32273,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@uniswap/lib": {
-      "version": "4.0.1-alpha",
-      "resolved": "https://registry.npmjs.org/@uniswap/lib/-/lib-4.0.1-alpha.tgz",
-      "integrity": "sha512-f6UIliwBbRsgVLxIaBANF6w09tYqc6Y/qXdsrbEmXHyFA7ILiKrIwRFXe1yOg8M3cksgVsO9N7yuL2DdCGQKBA=="
     },
     "@wry/context": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   ],
   "dependencies": {
     "@openzeppelin/contracts": "4.4.1",
-    "@uniswap/lib": "^4.0.1-alpha",
     "bignumber.js": "^9.0.0",
     "bluebird": "^3.3.5",
     "bn": "^1.0.1",


### PR DESCRIPTION
Removes the external uniswap dependency since we only rely on 2 of their functions.

ticket: BG-40975