### PR TITLE
fix: onERC721Received function signature to use external

### DIFF
--- a/contracts/Forwarder.sol
+++ b/contracts/Forwarder.sol
@@ -107,7 +107,7 @@ contract Forwarder is
     address _from,
     uint256 _tokenId,
     bytes memory _data
-  ) public virtual override nonReentrant returns (bytes4) {
+  ) external virtual override nonReentrant returns (bytes4) {
     if (autoFlush721) {
       IERC721 instance = IERC721(msg.sender);
       require(

--- a/contracts/WalletSimple.sol
+++ b/contracts/WalletSimple.sol
@@ -455,7 +455,7 @@ contract WalletSimple is ReentrancyGuard, IERC721Receiver, ERC1155Receiver {
     address _from,
     uint256 _tokenId,
     bytes memory _data
-  ) public virtual override returns (bytes4) {
+  ) external virtual override returns (bytes4) {
     return this.onERC721Received.selector;
   }
 

--- a/contracts/test/AlwaysFalseERC165.sol
+++ b/contracts/test/AlwaysFalseERC165.sol
@@ -25,7 +25,7 @@ contract AlwaysFalseERC165 is IERC165, IERC721Receiver {
     address from,
     uint256 tokenId,
     bytes memory data
-  ) public virtual override returns (bytes4) {
+  ) external virtual override returns (bytes4) {
     require(
       _delegateContract.supportsInterface(type(IERC721Receiver).interfaceId),
       'The delegate contract does not support the ERC721Receiver interface'


### PR DESCRIPTION
Changes the modifier to external to align with the contract interface.

ticket: BG-40980