### PR TITLE
fix: address minor audit fixes

### DIFF
--- a/ABIs/Forwarder.json
+++ b/ABIs/Forwarder.json
@@ -288,7 +288,7 @@
         "type": "uint256"
       }
     ],
-    "name": "flushERC721Tokens",
+    "name": "flushERC721Token",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/contracts/Forwarder.sol
+++ b/contracts/Forwarder.sol
@@ -106,13 +106,13 @@ contract Forwarder is
    * @param _operator The address which called `safeTransferFrom` function
    * @param _from The address of the sender
    * @param _tokenId The token id of the nft
-   * @param _data Additional data with no specified format, sent in call to `_to`
+   * @param data Additional data with no specified format, sent in call to `_to`
    */
   function onERC721Received(
     address _operator,
     address _from,
     uint256 _tokenId,
-    bytes memory _data
+    bytes memory data
   ) external virtual override nonReentrant returns (bytes4) {
     if (autoFlush721) {
       IERC721 instance = IERC721(msg.sender);
@@ -121,7 +121,7 @@ contract Forwarder is
         'The caller does not support the ERC721 interface'
       );
       // this won't work for ERC721 re-entrancy
-      instance.safeTransferFrom(address(this), parentAddress, _tokenId);
+      instance.safeTransferFrom(address(this), parentAddress, _tokenId, data);
     }
 
     return this.onERC721Received.selector;
@@ -214,7 +214,7 @@ contract Forwarder is
   /**
    * @inheritdoc IForwarder
    */
-  function flushERC721Tokens(address tokenContractAddress, uint256 tokenId)
+  function flushERC721Token(address tokenContractAddress, uint256 tokenId)
     external
     virtual
     override
@@ -226,14 +226,7 @@ contract Forwarder is
       'The tokenContractAddress does not support the ERC721 interface'
     );
 
-    address forwarderAddress = address(this);
     address ownerAddress = instance.ownerOf(tokenId);
-    address approvedAddress = instance.getApproved(tokenId);
-    require(
-      forwarderAddress == ownerAddress || forwarderAddress == approvedAddress,
-      'Not owner or approved of the ERC721 token'
-    );
-
     instance.transferFrom(ownerAddress, parentAddress, tokenId);
   }
 

--- a/contracts/IForwarder.sol
+++ b/contracts/IForwarder.sol
@@ -26,7 +26,7 @@ interface IForwarder is IERC165 {
    * @param tokenContractAddress the address of the ERC721 NFT contract
    * @param tokenId The token id of the nft
    */
-  function flushERC721Tokens(address tokenContractAddress, uint256 tokenId)
+  function flushERC721Token(address tokenContractAddress, uint256 tokenId)
     external;
 
   /**

--- a/contracts/WalletSimple.sol
+++ b/contracts/WalletSimple.sol
@@ -363,7 +363,7 @@ contract WalletSimple is ReentrancyGuard, IERC721Receiver, ERC1155Receiver {
       forwarder.supportsInterface(type(IForwarder).interfaceId),
       'The forwarder address does not support the IERC1155 interface'
     );
-    forwarder.flushERC721Tokens(tokenContractAddress, tokenId);
+    forwarder.flushERC721Token(tokenContractAddress, tokenId);
   }
 
   /**

--- a/test/forwarder.js
+++ b/test/forwarder.js
@@ -287,7 +287,7 @@ contract('Forwarder', function (accounts) {
         noAutoFlushForwarder.address
       );
 
-      await noAutoFlushForwarder.flushERC721Tokens(token721.address, tokenId, {
+      await noAutoFlushForwarder.flushERC721Token(token721.address, tokenId, {
         from: baseAddress
       });
       expect(await token721.ownerOf(tokenId)).to.be.equal(baseAddress);
@@ -304,7 +304,7 @@ contract('Forwarder', function (accounts) {
         autoFlushForwarder.address
       );
 
-      await autoFlushForwarder.flushERC721Tokens(token721.address, tokenId, {
+      await autoFlushForwarder.flushERC721Token(token721.address, tokenId, {
         from: baseAddress
       });
       expect(await token721.ownerOf(tokenId)).to.be.equal(baseAddress);
@@ -316,7 +316,7 @@ contract('Forwarder', function (accounts) {
       await token721.mint(owner, tokenId);
 
       try {
-        await autoFlushForwarder.flushERC721Tokens(token721.address, tokenId, {
+        await autoFlushForwarder.flushERC721Token(token721.address, tokenId, {
           from: baseAddress
         });
       } catch (err) {
@@ -585,7 +585,7 @@ contract('Forwarder', function (accounts) {
         'toggleAutoFlush721()',
         'toggleAutoFlush1155()',
         'flushTokens(address)',
-        'flushERC721Tokens(address,uint256)',
+        'flushERC721Token(address,uint256)',
         'flushERC1155Tokens(address,uint256)',
         'batchFlushERC1155Tokens(address,uint256[])'
       ])


### PR DESCRIPTION
Address the following issues found during the audit

```
(M-1) `flushERC721Tokens` overly restrictive

    Forwarder.sol’s `flushERC721Tokens` reverts unless the forwarder is the owner of the token, or if it’s approved for that specific token. However, this logic reverts even if the forwarder is an **operator** of the token’s owner via ERC-721’s `setApprovalForAll` function.

    Consider removing these checks and defering validation to `transferFrom`.

(M-2) Unused Parameter

    In Forwarder.sol’s `onERC721Received` function, `instance.safeTransferFrom` does not use the `_data` parameter like `onERC1155Received` does. Consider passing this through so no intended behavior is lost.
```

```
Nitpicks

- There’s a whitespace change in `tryInsertSequenceId`. Consider taking that out of the diff.
- Forwarder.sol’s `flushERC721Tokens` is plural, but it only transfers one token. Consider renaming it to be singular.
```

ticket: BG-41862