### PR TITLE
fix: address medium audit fixes

### DIFF
--- a/ABIs/Forwarder.json
+++ b/ABIs/Forwarder.json
@@ -68,25 +68,6 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "bytes4",
-        "name": "interfaceId",
-        "type": "bytes4"
-      }
-    ],
-    "name": "supportsInterface",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "stateMutability": "payable",
     "type": "receive"
   },
@@ -114,15 +95,27 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "toggleAutoFlush721",
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "autoFlush",
+        "type": "bool"
+      }
+    ],
+    "name": "setAutoFlush721",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "toggleAutoFlush1155",
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "autoFlush",
+        "type": "bool"
+      }
+    ],
+    "name": "setAutoFlush1155",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -146,7 +139,7 @@
       },
       {
         "internalType": "bytes",
-        "name": "_data",
+        "name": "data",
         "type": "bytes"
       }
     ],
@@ -294,10 +287,65 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenContractAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "flushERC1155Tokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenContractAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "tokenIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "batchFlushERC1155Tokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "flush",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   }
 ]

--- a/contracts/Forwarder.sol
+++ b/contracts/Forwarder.sol
@@ -88,15 +88,25 @@ contract Forwarder is
   /**
    * @inheritdoc IForwarder
    */
-  function toggleAutoFlush721() external virtual override onlyParent {
-    autoFlush721 = !autoFlush721;
+  function setAutoFlush721(bool autoFlush)
+    external
+    virtual
+    override
+    onlyParent
+  {
+    autoFlush721 = autoFlush;
   }
 
   /**
    * @inheritdoc IForwarder
    */
-  function toggleAutoFlush1155() external virtual override onlyParent {
-    autoFlush1155 = !autoFlush1155;
+  function setAutoFlush1155(bool autoFlush)
+    external
+    virtual
+    override
+    onlyParent
+  {
+    autoFlush1155 = autoFlush;
   }
 
   /**
@@ -113,7 +123,7 @@ contract Forwarder is
     address _from,
     uint256 _tokenId,
     bytes memory data
-  ) external virtual override nonReentrant returns (bytes4) {
+  ) external virtual override returns (bytes4) {
     if (autoFlush721) {
       IERC721 instance = IERC721(msg.sender);
       require(
@@ -131,9 +141,11 @@ contract Forwarder is
     address target,
     uint256 value,
     bytes calldata data
-  ) external nonReentrant onlyParent {
+  ) external nonReentrant onlyParent returns (bytes calldata) {
     (bool success, ) = target.call{ value: value }(data);
     require(success, 'Parent call execution failed');
+
+    return data;
   }
 
   /**
@@ -145,7 +157,7 @@ contract Forwarder is
     uint256 id,
     uint256 value,
     bytes calldata data
-  ) external virtual override nonReentrant returns (bytes4) {
+  ) external virtual override returns (bytes4) {
     IERC1155 instance = IERC1155(msg.sender);
     require(
       instance.supportsInterface(type(IERC1155).interfaceId),
@@ -168,7 +180,7 @@ contract Forwarder is
     uint256[] calldata ids,
     uint256[] calldata values,
     bytes calldata data
-  ) external virtual override nonReentrant returns (bytes4) {
+  ) external virtual override returns (bytes4) {
     IERC1155 instance = IERC1155(msg.sender);
     require(
       instance.supportsInterface(type(IERC1155).interfaceId),

--- a/contracts/IForwarder.sol
+++ b/contracts/IForwarder.sol
@@ -4,14 +4,18 @@ import '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 
 interface IForwarder is IERC165 {
   /**
-   * Toggles the autoflush721 parameter.
+   * Sets the autoflush721 parameter.
+   *
+   * @param autoFlush whether to autoflush erc721 tokens
    */
-  function toggleAutoFlush721() external;
+  function setAutoFlush721(bool autoFlush) external;
 
   /**
-   * Toggles the autoflush1155 parameter.
+   * Sets the autoflush1155 parameter.
+   *
+   * @param autoFlush whether to autoflush erc1155 tokens
    */
-  function toggleAutoFlush1155() external;
+  function setAutoFlush1155(bool autoFlush) external;
 
   /**
    * Execute a token transfer of the full balance from the forwarder token to the parent address

--- a/contracts/TransferHelper.sol
+++ b/contracts/TransferHelper.sol
@@ -2,6 +2,8 @@
 // source: https://github.com/Uniswap/solidity-lib/blob/master/contracts/libraries/TransferHelper.sol
 pragma solidity 0.8.10;
 
+import '@openzeppelin/contracts/utils/Address.sol';
+
 // helper methods for interacting with ERC20 tokens and sending ETH that do not consistently return true/false
 library TransferHelper {
   function safeTransfer(
@@ -26,11 +28,12 @@ library TransferHelper {
     uint256 value
   ) internal {
     // bytes4(keccak256(bytes('transferFrom(address,address,uint256)')));
-    (bool success, bytes memory data) = token.call(
+    (bool success, bytes memory returndata) = token.call(
       abi.encodeWithSelector(0x23b872dd, from, to, value)
     );
-    require(
-      success && (data.length == 0 || abi.decode(data, (bool))),
+    Address.verifyCallResult(
+      success,
+      returndata,
       'TransferHelper::transferFrom: transferFrom failed'
     );
   }

--- a/contracts/WalletSimple.sol
+++ b/contracts/WalletSimple.sol
@@ -408,31 +408,39 @@ contract WalletSimple is ReentrancyGuard, IERC721Receiver, ERC1155Receiver {
   }
 
   /**
-   * Toggles the autoflush 721 parameter on the forwarder.
+   * Sets the autoflush 721 parameter on the forwarder.
    *
    * @param forwarderAddress the address of the forwarder to toggle.
+   * @param autoFlush whether to autoflush erc721 tokens
    */
-  function toggleAutoFlush721(address forwarderAddress) external onlySigner {
+  function setAutoFlush721(address forwarderAddress, bool autoFlush)
+    external
+    onlySigner
+  {
     IForwarder forwarder = IForwarder(forwarderAddress);
     require(
       forwarder.supportsInterface(type(IForwarder).interfaceId),
       'The forwarder address does not support the IERC1155 interface'
     );
-    forwarder.toggleAutoFlush721();
+    forwarder.setAutoFlush721(autoFlush);
   }
 
   /**
-   * Toggles the autoflush 721 parameter on the forwarder.
+   * Sets the autoflush 721 parameter on the forwarder.
    *
    * @param forwarderAddress the address of the forwarder to toggle.
+   * @param autoFlush whether to autoflush erc1155 tokens
    */
-  function toggleAutoFlush1155(address forwarderAddress) external onlySigner {
+  function setAutoFlush1155(address forwarderAddress, bool autoFlush)
+    external
+    onlySigner
+  {
     IForwarder forwarder = IForwarder(forwarderAddress);
     require(
       forwarder.supportsInterface(type(IForwarder).interfaceId),
       'The forwarder address does not support the IERC1155 interface'
     );
-    forwarder.toggleAutoFlush1155();
+    forwarder.setAutoFlush1155(autoFlush);
   }
 
   /**
@@ -607,7 +615,7 @@ contract WalletSimple is ReentrancyGuard, IERC721Receiver, ERC1155Receiver {
    * Gets the next available sequence ID for signing when using executeAndConfirm
    * returns the sequenceId one higher than the highest currently stored
    */
-  function getNextSequenceId() public view returns (uint256) {
+  function getNextSequenceId() external view returns (uint256) {
     uint256 highestSequenceId = 0;
     for (uint256 i = 0; i < SEQUENCE_ID_WINDOW_SIZE; i++) {
       if (recentSequenceIds[i] > highestSequenceId) {

--- a/test/forwarder.js
+++ b/test/forwarder.js
@@ -131,12 +131,12 @@ contract('Forwarder', function (accounts) {
     );
   });
 
-  it('should toggle autoFlush721 when calling toggleAutoFlush721', async () => {
+  it('should change autoFlush721 when calling setAutoFlush721', async () => {
     const baseAddress = accounts[3];
     const forwarder = await createForwarder(baseAddress, baseAddress);
 
     const initialState = await forwarder.autoFlush721();
-    await forwarder.toggleAutoFlush721({ from: baseAddress });
+    await forwarder.setAutoFlush721(!initialState, { from: baseAddress });
 
     const newState = await forwarder.autoFlush721();
     initialState.should.equal(!newState);
@@ -147,16 +147,16 @@ contract('Forwarder', function (accounts) {
     const forwarder = await createForwarder(baseAddress, baseAddress);
 
     await truffleAssert.reverts(
-      forwarder.toggleAutoFlush721({ from: accounts[4] })
+      forwarder.setAutoFlush721(false, { from: accounts[4] })
     );
   });
 
-  it('should toggle autoFlush1155 when calling toggleAutoFlush1155', async () => {
+  it('should toggle autoFlush1155 when calling setAutoFlush1155', async () => {
     const baseAddress = accounts[3];
     const forwarder = await createForwarder(baseAddress, baseAddress);
 
     const initialState = await forwarder.autoFlush1155();
-    await forwarder.toggleAutoFlush1155({ from: baseAddress });
+    await forwarder.setAutoFlush1155(!initialState, { from: baseAddress });
 
     const newState = await forwarder.autoFlush1155();
     initialState.should.equal(!newState);
@@ -167,7 +167,7 @@ contract('Forwarder', function (accounts) {
     const forwarder = await createForwarder(baseAddress, baseAddress);
 
     await truffleAssert.reverts(
-      forwarder.toggleAutoFlush1155({ from: accounts[4] })
+      forwarder.setAutoFlush1155(false, { from: accounts[4] })
     );
   });
 
@@ -582,8 +582,8 @@ contract('Forwarder', function (accounts) {
         'onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)'
       ]),
       IForwarder: makeInterfaceId.ERC165([
-        'toggleAutoFlush721()',
-        'toggleAutoFlush1155()',
+        'setAutoFlush721(bool)',
+        'setAutoFlush1155(bool)',
         'flushTokens(address)',
         'flushERC721Token(address,uint256)',
         'flushERC1155Tokens(address,uint256)',

--- a/test/walletsimple.js
+++ b/test/walletsimple.js
@@ -2500,13 +2500,13 @@ coins.forEach(
 
         it('should toggle auto flush 721', async function () {
           const autoFlush721 = await forwarder.autoFlush721();
-          await wallet.toggleAutoFlush721(forwarder.address);
+          await wallet.setAutoFlush721(forwarder.address, !autoFlush721);
           (await forwarder.autoFlush721()).should.equal(!autoFlush721);
         });
 
         it('should toggle auto flush 1155', async function () {
           const autoFlush1155 = await forwarder.autoFlush1155();
-          await wallet.toggleAutoFlush1155(forwarder.address);
+          await wallet.setAutoFlush1155(forwarder.address, !autoFlush1155);
           (await forwarder.autoFlush1155()).should.equal(!autoFlush1155);
         });
 


### PR DESCRIPTION
Fixes the following issues

```
(L-1) Forwarder cannot receive tokens in edge case

    Both Forwarder’s `callFromParent` and receive callbacks (`onERC721Received`, etc) have the `nonReentrant` modifier. Because of this, any function call made through `callFromParent` will prevent the Forwarder from receiving any ERC-721 and ERC-1155 tokens.

    Consider removing `nonReentrant` from the receive callbacks.

(L-2) Toggle functions race condition

    `toggleAutoFlush721` and `toggleAutoFlush1155` are vulnerable to a user-based race condition. If two signers Alice and Bob independently decide – in parallel – to toggle *on* an auto flush, their two transactions will cancel each other out, leaving the auto flush *off*.

    Consider updating these functions to be idempotent by accepting a `boolean` parameter, instead of reading from the current state of the contract.

(Q-1) No return data

    Consider making Forwarder.sol’s `callFromParent` return its low-level call’s return data (like Batcher.sol's `recover`) to allow greater flexibility for parent contracts.

(Q-2) Redundant getter

    WalletSimple.sol’s `function isSigner(address)` is redundant; the `public` keyword on the `public signers` definition generates a getter function `function signers(address)`.

    Consider removing one of the two to save on code size.

(Q-3) Function visibility

    - WalletSimple.sol’s `getNextSequenceId` can be marked external instead of public.

(Q-4) Error message improvement

    Within the functions of TransferHelper.sol, if an error happens during transfer, the code does not report the error message of that failed transfer (when such a message is present). Instead, `TransferHelper::safeTransfer: transfer failed` is always thrown.

    For better UX/DX, consider using an approach like OpenZeppelin’s `verifyCallResult` function from its Address library, which bubbles up an error message from a low-level call when one is present.

    See https://github.com/OpenZeppelin/openzeppelin-contracts/blob/fd7c4ba8f0f08ebb70762f1ee48250d5cad5fc48/contracts/utils/Address.sol#L201
```


ticket: BG-41862