### PR TITLE
fix: call from parent returned call data

### DIFF
--- a/contracts/Forwarder.sol
+++ b/contracts/Forwarder.sol
@@ -135,11 +135,13 @@ contract Forwarder is IERC721Receiver, ERC1155Receiver, IForwarder {
     address target,
     uint256 value,
     bytes calldata data
-  ) external onlyParent returns (bytes calldata) {
-    (bool success, ) = target.call{ value: value }(data);
+  ) external onlyParent returns (bytes memory) {
+    (bool success, bytes memory returnedData) = target.call{ value: value }(
+      data
+    );
     require(success, 'Parent call execution failed');
 
-    return data;
+    return returnedData;
   }
 
   /**


### PR DESCRIPTION
> Description
Data returned by transactions is ignored, greatly limiting wallet functionality.
contracts/WalletSimple.sol
210 (bool success, ) = toAddress.call{ value: valu.e }(data);↤
The Forwarder callFromParent function ignores the returned call data and returns
the data parameter instead.
contracts/Forwarder.sol
134 function callFromParent(
135 address target,
136 uint256 value,
137 bytes calldata data
138 ) external onlyParent returns (bytes calldata) {
139 (bool success, ) = target.call{ value: value }(data);↤
140 require(success, 'Parent call execution failed');
141 return data;↤
142 }
Recommendation
Consider returning calls returned data.

Fixes the above audit issue.

ticket: BG-43312