### PR TITLE
fix: missing require success statement in batcher recover calls

### DIFF
--- a/contracts/Batcher.sol
+++ b/contracts/Batcher.sol
@@ -92,6 +92,7 @@ contract Batcher {
     bytes calldata data
   ) external onlyOwner returns (bytes memory) {
     (bool success, bytes memory returnData) = to.call{ value: value }(data);
+    require(success, 'Recover failed');
     return returnData;
   }
 

--- a/test/batcher.js
+++ b/test/batcher.js
@@ -49,7 +49,7 @@ const assertVMException = async (promise, expectedExceptionMsg) => {
     assert.strictEqual(
       err.message,
       `VM Exception while processing transaction: reverted with reason string '${expectedExceptionMsg}'`,
-      "Invalid exception"
+      'Invalid exception'
     );
   }
   if (badSucceed) {
@@ -74,7 +74,7 @@ describe('Batcher', () => {
   const zeroAddr = '0x0000000000000000000000000000000000000000';
 
   before(async () => {
-    await hre.network.provider.send("hardhat_reset");
+    await hre.network.provider.send('hardhat_reset');
     accounts = await web3.eth.getAccounts();
     sender = accounts[0];
     batcherOwner = accounts[8];
@@ -595,9 +595,12 @@ describe('Batcher', () => {
       await runTestBatcherDriver(params);
       const beforeWalletBalance = await getBalance(recoverAddress);
 
-      await batcherInstance.recover(recoverAddress, 60, 0, {
-        from: batcherOwner
-      });
+      await assertVMException(
+        batcherInstance.recover(recoverAddress, 60, 0, {
+          from: batcherOwner
+        }),
+        'Recover failed'
+      );
 
       const recoverWalletBalance = await getBalance(recoverAddress);
       assert.strictEqual(
@@ -608,7 +611,6 @@ describe('Batcher', () => {
     });
 
     describe('Transferring ownership and setting gas transfer limit', () => {
-
       // note: at the start of every test, the Batcher owner should be `batcherOwner`
       // and the transfer gas limit should be the default
       const defaultTransferGasLimit = 1e4;


### PR DESCRIPTION
> Batcher’s recovery function does not verify call success. Contracts calling this function
might expect the transaction to fail if the call was not successful
89 function recover(
90 address to,
91 uint256 value,
92 bytes calldata data
93 ) external onlyOwner returns (bytes memory) {
94 (bool success, bytes memory returnData) = to.call{ value: value }(data);↤
95 return returnData;
96 }
Recommendation
Require transaction success

Fixes the above audit issue.

ticket: BG-43313