### PR TITLE
feat(eth-multisig-v4): add polygon support

### DIFF
--- a/contracts/coins/PolygonWalletSimple.sol
+++ b/contracts/coins/PolygonWalletSimple.sol
@@ -30,13 +30,13 @@ import '../WalletSimple.sol';
  *
  *
  */
-contract MaticLWalletSimple is WalletSimple {
+contract PolygonWalletSimple is WalletSimple {
   /**
    * Get the network identifier that signers must sign over
    * This provides protection signatures being replayed on other chains
    */
   function getNetworkId() internal override pure returns (string memory) {
-    return 'MATICL';
+    return 'POLYGON';
   }
 
   /**
@@ -44,7 +44,7 @@ contract MaticLWalletSimple is WalletSimple {
    * This provides protection signatures being replayed on other chains
    */
   function getTokenNetworkId() internal override pure returns (string memory) {
-    return 'MATICL-ERC20';
+    return 'POLYGON-ERC20';
   }
 
   /**
@@ -52,6 +52,6 @@ contract MaticLWalletSimple is WalletSimple {
    * This provides protection signatures being replayed on other chains
    */
   function getBatchNetworkId() internal override pure returns (string memory) {
-    return 'MATICL-Batch';
+    return 'POLYGON-Batch';
   }
 }

--- a/test/walletSimple.js
+++ b/test/walletSimple.js
@@ -27,7 +27,7 @@ const EthWalletSimple = artifacts.require('./WalletSimple.sol');
 const RskWalletSimple = artifacts.require('./RskWalletSimple.sol');
 const EtcWalletSimple = artifacts.require('./EtcWalletSimple.sol');
 const CeloWalletSimple = artifacts.require('./CeloWalletSimple.sol');
-const MaticLWalletSimple = artifacts.require('./MaticLWalletSimple.sol');
+const PolygonWalletSimple = artifacts.require('./PolygonWalletSimple.sol');
 const Fail = artifacts.require('./Fail.sol');
 const GasGuzzler = artifacts.require('./GasGuzzler.sol');
 const GasHeavy = artifacts.require('./GasHeavy.sol');
@@ -73,11 +73,11 @@ const coins = [
     WalletSimple: CeloWalletSimple
   },
   {
-    name: 'MaticL',
-    nativePrefix: 'MATICL',
-    nativeBatchPrefix: 'MATICL-Batch',
-    tokenPrefix: 'MATICL-ERC20',
-    WalletSimple: MaticLWalletSimple
+    name: 'Polygon',
+    nativePrefix: 'POLYGON',
+    nativeBatchPrefix: 'POLYGON-Batch',
+    tokenPrefix: 'POLYGON-ERC20',
+    WalletSimple: PolygonWalletSimple
   }
 ];
 


### PR DESCRIPTION
This commit adds support for Polygon. The main change for this chain is that the operation hash prefix must be specific to the chain, to avoid cross-chain replay attacks. For example, on ETH chain it is the
string "ETHER", on POLYGON chain it is the string "POLYGON".

[BG-43071](https://bitgoinc.atlassian.net/browse/BG-43071)