### PR TITLE
feat: pack sequence ids to save gas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ output.json
 artifacts
 cache
 typechain
+out/

--- a/contracts/libraries/SequenceIdArray.sol
+++ b/contracts/libraries/SequenceIdArray.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.10;
+
+/// @notice Helper functions for the sequence id array
+/// @dev sequence ids are stored tightly packed in a uint256
+/// as 10 24-bit unsigned integers, i.e.
+/// 0xbbbbbbaaaaaa where 0xaaaaaa is index 0 and 0xbbbbbb is index 1
+library SequenceIdArray {
+  function getId(uint256 sequenceIds, uint256 index) internal pure returns (uint24) {
+    uint256 mask = 0xffffff << (index * 24);
+    return uint24((sequenceIds & mask) >> (index * 24));
+  }
+
+  function setId(uint256 sequenceIds, uint8 index, uint24 newId) internal pure returns (uint256) {
+    uint256 zeroMask = ~(0xffffff << (index * 24));
+    uint256 valueMask = uint256(newId) << (index * 24);
+    return (sequenceIds & zeroMask) | valueMask;
+  }
+}

--- a/contracts/test/SequenceIdTest.sol
+++ b/contracts/test/SequenceIdTest.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.10;
+
+import '../libraries/SequenceIdArray.sol';
+
+contract SequenceIdTest {
+  using SequenceIdArray for uint256;
+
+  uint256 public sequenceIds;
+
+  constructor() {}
+
+  function get(uint256 index) external view returns (uint24) {
+    return sequenceIds.getId(index);
+  }
+
+  function set(uint8 index, uint24 value) external {
+    sequenceIds = sequenceIds.setId(index, value);
+  }
+}

--- a/test/gas.js
+++ b/test/gas.js
@@ -120,7 +120,7 @@ describe(`Wallet Operations Gas Usage`, function () {
       .eq(destinationEndBalance)
       .should.be.true();
 
-    checkGasUsed(99618, transaction.receipt.gasUsed);
+    checkGasUsed(91418, transaction.receipt.gasUsed);
   });
 
   const sendBatchHelper = async (batchSize) => {
@@ -178,8 +178,8 @@ describe(`Wallet Operations Gas Usage`, function () {
 
   it('WalletSimple send batch [ @skip-on-coverage ]', async function () {
     const gasUsageByBatchSize = [
-      101938, 113244, 124585, 135902, 147219, 158538, 169855, 181172, 192490,
-      203796
+      93753, 105071, 116400, 127717, 139022, 150328, 161670, 172987, 184304,
+      195610
     ];
 
     for (let batchSize = 1; batchSize <= 10; batchSize++) {

--- a/test/sequenceIdBitmap.js
+++ b/test/sequenceIdBitmap.js
@@ -1,0 +1,44 @@
+const should = require('should');
+
+const truffleAssert = require('truffle-assertions');
+const helpers = require('./helpers');
+const BigNumber = require('bignumber.js');
+const { makeInterfaceId } = require('@openzeppelin/test-helpers');
+
+const SequenceIdTest = artifacts.require('./SequenceIdTest.sol');
+const util = require('ethereumjs-util');
+const abi = require('ethereumjs-abi');
+const hre = require('hardhat');
+
+describe('SequenceIdBitmap', function () {
+  let sequenceIdTest;
+
+  beforeEach(async () => {
+    sequenceIdTest = await SequenceIdTest.new();
+  });
+
+  it('gets values', async function () {
+    for (let i = 0; i < 10; i++) {
+      expect((await sequenceIdTest.get(i)).toNumber()).to.equal(0);
+    }
+  });
+
+  it('sets value at index 0', async function () {
+    await sequenceIdTest.set(0, 500);
+    expect((await sequenceIdTest.get(0)).toNumber()).to.equal(500);
+
+    for (let i = 1; i < 10; i++) {
+      expect((await sequenceIdTest.get(i)).toNumber()).to.equal(0);
+    }
+  });
+
+  it('sets all values', async function () {
+    for (let i = 0; i < 10; i++) {
+      await sequenceIdTest.set(i, i + 100);
+    }
+
+    for (let i = 1; i < 10; i++) {
+      expect((await sequenceIdTest.get(i)).toNumber()).to.equal(100 + i);
+    }
+  });
+});


### PR DESCRIPTION
The sequence id system for WalletSimple is quite well bounded - the
array of recently used ids has a max length of 10 and their values
generally stay quite low. This commit changes the storage model for the
array to use a single uint256 with 10 tightly packed uint24 values. This
saves 9 sloads over the course of a sendMultiSig, saving about 10k gas.