### PR TITLE
WIP/POC: Clone Immutable Args

### DIFF
--- a/contracts/ForwarderFactory.sol
+++ b/contracts/ForwarderFactory.sol
@@ -4,7 +4,7 @@ import './Forwarder.sol';
 import './CloneFactory.sol';
 
 contract ForwarderFactory is CloneFactory {
-  address public implementationAddress;
+  address public immutable implementationAddress;
 
   event ForwarderCreated(
     address newForwarderAddress,
@@ -30,9 +30,8 @@ contract ForwarderFactory is CloneFactory {
     // include the signers in the salt so any contract deployed to a given address must have the same signers
     bytes32 finalSalt = keccak256(abi.encodePacked(parent, salt));
 
-    address payable clone = createClone(implementationAddress, finalSalt);
+    address payable clone = clone(implementationAddress, finalSalt, abi.encodePacked(parent));
     Forwarder(clone).init(
-      parent,
       shouldAutoFlushERC721,
       shouldAutoFlushERC1155
     );
@@ -42,5 +41,10 @@ contract ForwarderFactory is CloneFactory {
       shouldAutoFlushERC721,
       shouldAutoFlushERC1155
     );
+  }
+
+  function computeForwarderAddress(address parent, bytes32 salt) external view returns (address) {
+    bytes32 finalSalt = keccak256(abi.encodePacked(parent, salt));
+    return computeCloneAddress(implementationAddress, finalSalt, abi.encodePacked(parent));
   }
 }

--- a/contracts/WalletFactory.sol
+++ b/contracts/WalletFactory.sol
@@ -4,7 +4,7 @@ import './WalletSimple.sol';
 import './CloneFactory.sol';
 
 contract WalletFactory is CloneFactory {
-  address public implementationAddress;
+  address public immutable implementationAddress;
 
   event WalletCreated(address newWalletAddress, address[] allowedSigners);
 
@@ -18,8 +18,13 @@ contract WalletFactory is CloneFactory {
     // include the signers in the salt so any contract deployed to a given address must have the same signers
     bytes32 finalSalt = keccak256(abi.encodePacked(allowedSigners, salt));
 
-    address payable clone = createClone(implementationAddress, finalSalt);
-    WalletSimple(clone).init(allowedSigners);
+    address payable clone = clone(implementationAddress, finalSalt, abi.encodePacked(allowedSigners[0], allowedSigners[1], allowedSigners[2]));
+    WalletSimple(clone).init();
     emit WalletCreated(clone, allowedSigners);
+  }
+
+  function computeWalletAddress(address[] calldata allowedSigners, bytes32 salt) external view returns (address) {
+    bytes32 finalSalt = keccak256(abi.encodePacked(allowedSigners, salt));
+    return computeCloneAddress(implementationAddress, finalSalt, abi.encodePacked(allowedSigners[0], allowedSigners[1], allowedSigners[2]));
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "bluebird": "^3.3.5",
     "bn": "^1.0.1",
     "bn.js": "^4.11.3",
+    "clones-with-immutable-args": "^1.0.0",
     "ethereumjs-abi": "^0.6.8",
     "ethereumjs-util": "^7.0.4",
     "ganache-cli": "^6.12.2",
@@ -72,11 +73,11 @@
     "solhint": "^3.3.6",
     "solhint-plugin-prettier": "0.0.5",
     "solidity-coverage": "^0.7.18",
+    "truffle-assertions": "^0.9.2",
     "ts-node": "^10.4.0",
     "typechain": "^5.2.0",
     "typescript": "^4.5.5",
-    "web3": "^1.7.0",
-    "truffle-assertions": "^0.9.2"
+    "web3": "^1.7.0"
   },
   "engines": {
     "node": ">=14.17.5 <15",

--- a/test/forwarderFactory.js
+++ b/test/forwarderFactory.js
@@ -26,6 +26,7 @@ const getBalanceInWei = async (address) => {
   return new BigNumber(await web3.eth.getBalance(address));
 };
 
+
 const createForwarder = async (
   factory,
   implementationAddress,
@@ -269,3 +270,5 @@ describe('ForwarderFactory', function () {
     );
   });
 });
+
+exports.createForwarderFactory = createForwarderFactory;

--- a/test/gas.js
+++ b/test/gas.js
@@ -67,7 +67,7 @@ describe(`Wallet Operations Gas Usage`, function () {
       accounts[1],
       accounts[2]
     ]);
-    checkGasUsed(171030, transaction.receipt.gasUsed);
+    checkGasUsed(114501, transaction.receipt.gasUsed);
   });
 
   it('WalletSimple send [ @skip-on-coverage ]', async function () {
@@ -120,7 +120,7 @@ describe(`Wallet Operations Gas Usage`, function () {
       .eq(destinationEndBalance)
       .should.be.true();
 
-    checkGasUsed(99618, transaction.receipt.gasUsed);
+    checkGasUsed(95849, transaction.receipt.gasUsed);
   });
 
   const sendBatchHelper = async (batchSize) => {
@@ -178,8 +178,8 @@ describe(`Wallet Operations Gas Usage`, function () {
 
   it('WalletSimple send batch [ @skip-on-coverage ]', async function () {
     const gasUsageByBatchSize = [
-      101938, 113244, 124585, 135902, 147219, 158538, 169855, 181172, 192490,
-      203796
+      98122, 109440, 120769, 132074, 143392, 154722, 166027, 177356, 188651,
+      199980
     ];
 
     for (let batchSize = 1; batchSize <= 10; batchSize++) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -147,6 +147,18 @@ exports.assertVMException = async (fn) => {
   failed.should.equal(true);
 };
 
+exports.assertCreateFail = async (fn) => {
+  let failed = false;
+  try {
+    await fn();
+  } catch (err) {
+    err.message.toString().should.containEql('CreateFail()');
+    failed = true;
+  }
+
+  failed.should.equal(true);
+};
+
 exports.getInitCode = (targetAddress) => {
   const target = util
     .stripHexPrefix(targetAddress.toLowerCase())

--- a/test/wallet/helpers.js
+++ b/test/wallet/helpers.js
@@ -107,8 +107,8 @@ const createWalletHelper = async (WalletSimple, creator, signers) => {
     calculationSalt,
     initCode
   );
-  await factory.createWallet(signers, inputSalt, { from: creator });
-  return WalletSimple.at(walletAddress);
+  const tx = await factory.createWallet(signers, inputSalt, { from: creator });
+  return WalletSimple.at(tx.logs[0].args.newWalletAddress);
 };
 
 const getBalanceInWei = async (address) => {
@@ -134,3 +134,4 @@ exports.createWalletHelper = createWalletHelper;
 exports.getBalanceInWei = getBalanceInWei;
 exports.calculateFutureExpireTime = calculateFutureExpireTime;
 exports.isSigner = isSigner;
+exports.createWalletFactory = createWalletFactory;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3297,6 +3297,11 @@ clone@2.1.2, clone@^2.0.0, clone@^2.1.1:
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
+clones-with-immutable-args@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clones-with-immutable-args/-/clones-with-immutable-args-1.0.0.tgz#f2ddaa02214575ceae35f7bfbf976a528d455e3b"
+  integrity sha512-DYv2cgcmNuNaxa00Q/HSWAnsIc8H0mMjZHyGHxHUuyj3JoApOS2dcEb9SQ53qCy3SvDAhKZdaHSNHxbLvlIawg==
+
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"


### PR DESCRIPTION
this commit is a proof of concept for using immutable args with clones
for the deployed WalletSimple and Forwarder clones. Immutable args are
much cheaper to read than storage args, and using the library
clones-with-immutable-args we can get effectively immutable cost on
proxy/clones. We had to tweak the library a bit to get it to work
properly with create2, and some tests are still failing.

This saves about 55k gas for deploying wallets and 4k for sending
transfers