### PR TITLE
address audit feedback

### DIFF
--- a/contracts/Batcher.sol
+++ b/contracts/Batcher.sol
@@ -71,12 +71,12 @@ contract Batcher {
     // Revert everything if any transfer fails
     for (uint8 i = 0; i < recipients.length; i++) {
       require(recipients[i] != address(0), 'Invalid recipient address');
+      emit BatchTransfer(msg.sender, recipients[i], values[i]);
       (bool success, ) = recipients[i].call{
         value: values[i],
         gas: transferGasLimit
       }('');
       require(success, 'Send failed');
-      emit BatchTransfer(msg.sender, recipients[i], values[i]);
     }
   }
 

--- a/contracts/Forwarder.sol
+++ b/contracts/Forwarder.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.20;
 import '@openzeppelin/contracts/token/ERC1155/IERC1155.sol';
 import '@openzeppelin/contracts/token/ERC721/IERC721.sol';
 import '@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol';
-import '@openzeppelin/contracts/token/ERC1155/utils/ERC1155Receiver.sol';
+import '@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol';
 import './ERC20Interface.sol';
 import './TransferHelper.sol';
 import './IForwarder.sol';
@@ -12,7 +12,7 @@ import './IForwarder.sol';
  * Contract that will forward any incoming Ether to the creator of the contract
  *
  */
-contract Forwarder is IERC721Receiver, ERC1155Receiver, IForwarder {
+contract Forwarder is IERC721Receiver, ERC1155Holder, IForwarder {
   // Address to which any funds sent to this contract will be forwarded
   address public parentAddress;
   bool public autoFlush721 = true;
@@ -145,15 +145,15 @@ contract Forwarder is IERC721Receiver, ERC1155Receiver, IForwarder {
   }
 
   /**
-   * @inheritdoc IERC1155Receiver
+   * @inheritdoc ERC1155Holder
    */
   function onERC1155Received(
     address _operator,
     address _from,
     uint256 id,
     uint256 value,
-    bytes calldata data
-  ) external virtual override returns (bytes4) {
+    bytes memory data
+  ) public virtual override returns (bytes4) {
     IERC1155 instance = IERC1155(msg.sender);
     require(
       instance.supportsInterface(type(IERC1155).interfaceId),
@@ -168,15 +168,15 @@ contract Forwarder is IERC721Receiver, ERC1155Receiver, IForwarder {
   }
 
   /**
-   * @inheritdoc IERC1155Receiver
+   * @inheritdoc ERC1155Holder
    */
   function onERC1155BatchReceived(
     address _operator,
     address _from,
-    uint256[] calldata ids,
-    uint256[] calldata values,
-    bytes calldata data
-  ) external virtual override returns (bytes4) {
+    uint256[] memory ids,
+    uint256[] memory values,
+    bytes memory data
+  ) public virtual override returns (bytes4) {
     IERC1155 instance = IERC1155(msg.sender);
     require(
       instance.supportsInterface(type(IERC1155).interfaceId),
@@ -315,7 +315,7 @@ contract Forwarder is IERC721Receiver, ERC1155Receiver, IForwarder {
     public
     view
     virtual
-    override(ERC1155Receiver, IERC165)
+    override(ERC1155Holder, IERC165)
     returns (bool)
   {
     return

--- a/contracts/Forwarder.sol
+++ b/contracts/Forwarder.sol
@@ -39,14 +39,14 @@ contract Forwarder is IERC721Receiver, ERC1155Receiver, IForwarder {
       return;
     }
 
-    (bool success, ) = parentAddress.call{ value: value }('');
-    require(success, 'Flush failed');
-
     // NOTE: since we are forwarding on initialization,
     // we don't have the context of the original sender.
     // We still emit an event about the forwarding but set
     // the sender to the forwarder itself
     emit ForwarderDeposited(address(this), value, msg.data);
+
+    (bool success, ) = parentAddress.call{ value: value }('');
+    require(success, 'Flush failed');
   }
 
   /**
@@ -303,9 +303,9 @@ contract Forwarder is IERC721Receiver, ERC1155Receiver, IForwarder {
       return;
     }
 
+    emit ForwarderDeposited(msg.sender, value, msg.data);
     (bool success, ) = parentAddress.call{ value: value }('');
     require(success, 'Flush failed');
-    emit ForwarderDeposited(msg.sender, value, msg.data);
   }
 
   /**

--- a/contracts/ForwarderFactory.sol
+++ b/contracts/ForwarderFactory.sol
@@ -31,13 +31,14 @@ contract ForwarderFactory is CloneFactory {
     bytes32 finalSalt = keccak256(abi.encodePacked(parent, salt));
 
     address payable clone = createClone(implementationAddress, finalSalt);
-    Forwarder(clone).init(
+
+    emit ForwarderCreated(
+      clone,
       parent,
       shouldAutoFlushERC721,
       shouldAutoFlushERC1155
     );
-    emit ForwarderCreated(
-      clone,
+    Forwarder(clone).init(
       parent,
       shouldAutoFlushERC721,
       shouldAutoFlushERC1155

--- a/contracts/ForwarderFactory.sol
+++ b/contracts/ForwarderFactory.sol
@@ -4,7 +4,7 @@ import './Forwarder.sol';
 import './CloneFactory.sol';
 
 contract ForwarderFactory is CloneFactory {
-  address public implementationAddress;
+  address public immutable implementationAddress;
 
   event ForwarderCreated(
     address newForwarderAddress,

--- a/contracts/ForwarderFactoryV4.sol
+++ b/contracts/ForwarderFactoryV4.sol
@@ -67,14 +67,14 @@ contract ForwarderFactoryV4 is CloneFactory {
     bytes32 finalSalt = keccak256(abi.encodePacked(parent, feeAddress, salt));
 
     address payable clone = createClone(implementationAddress, finalSalt);
-    ForwarderV4(clone).init(
+    emit ForwarderCreated(
+      clone,
       parent,
       feeAddress,
       shouldAutoFlushERC721,
       shouldAutoFlushERC1155
     );
-    emit ForwarderCreated(
-      clone,
+    ForwarderV4(clone).init(
       parent,
       feeAddress,
       shouldAutoFlushERC721,

--- a/contracts/ForwarderFactoryV4.sol
+++ b/contracts/ForwarderFactoryV4.sol
@@ -8,7 +8,7 @@ import './CloneFactory.sol';
  * @notice This contract will deploy new forwarder contracts using the create2 opcode
  */
 contract ForwarderFactoryV4 is CloneFactory {
-  address public implementationAddress;
+  address public immutable implementationAddress;
 
   /**
    * @notice Event triggered when a new forwarder is deployed

--- a/contracts/ForwarderV4.sol
+++ b/contracts/ForwarderV4.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.20;
 import '@openzeppelin/contracts/token/ERC1155/IERC1155.sol';
 import '@openzeppelin/contracts/token/ERC721/IERC721.sol';
 import '@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol';
-import '@openzeppelin/contracts/token/ERC1155/utils/ERC1155Receiver.sol';
+import '@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol';
 import './ERC20Interface.sol';
 import './TransferHelper.sol';
 import './IForwarderV4.sol';
@@ -12,7 +12,7 @@ import './IForwarderV4.sol';
  * @title ForwarderV4
  * @notice This contract will forward any incoming Ether or token to the parent address of the contract
  */
-contract ForwarderV4 is IERC721Receiver, ERC1155Receiver, IForwarderV4 {
+contract ForwarderV4 is IERC721Receiver, ERC1155Holder, IForwarderV4 {
   /// @notice Any funds sent to this contract will be forwarded to this address
   address public parentAddress;
   /// @notice Address which is allowed to call methods on this contract alongwith the parentAddress
@@ -173,15 +173,15 @@ contract ForwarderV4 is IERC721Receiver, ERC1155Receiver, IForwarderV4 {
   }
 
   /**
-   * @inheritdoc IERC1155Receiver
+   * @inheritdoc ERC1155Holder
    */
   function onERC1155Received(
     address _operator,
     address _from,
     uint256 id,
     uint256 value,
-    bytes calldata data
-  ) external virtual override returns (bytes4) {
+    bytes memory data
+  ) public virtual override returns (bytes4) {
     IERC1155 instance = IERC1155(msg.sender);
     require(
       instance.supportsInterface(type(IERC1155).interfaceId),
@@ -196,15 +196,15 @@ contract ForwarderV4 is IERC721Receiver, ERC1155Receiver, IForwarderV4 {
   }
 
   /**
-   * @inheritdoc IERC1155Receiver
+   * @inheritdoc ERC1155Holder
    */
   function onERC1155BatchReceived(
     address _operator,
     address _from,
-    uint256[] calldata ids,
-    uint256[] calldata values,
-    bytes calldata data
-  ) external virtual override returns (bytes4) {
+    uint256[] memory ids,
+    uint256[] memory values,
+    bytes memory data
+  ) public virtual override returns (bytes4) {
     IERC1155 instance = IERC1155(msg.sender);
     require(
       instance.supportsInterface(type(IERC1155).interfaceId),
@@ -370,7 +370,7 @@ contract ForwarderV4 is IERC721Receiver, ERC1155Receiver, IForwarderV4 {
     public
     view
     virtual
-    override(ERC1155Receiver, IERC165)
+    override(ERC1155Holder, IERC165)
     returns (bool)
   {
     return

--- a/contracts/ForwarderV4.sol
+++ b/contracts/ForwarderV4.sol
@@ -89,9 +89,6 @@ contract ForwarderV4 is IERC721Receiver, ERC1155Receiver, IForwarderV4 {
       return;
     }
 
-    (bool success, ) = parentAddress.call{ value: value }('');
-    require(success, 'Flush failed');
-
     /**
      * Since we are forwarding on initialization,
      * we don't have the context of the original sender.
@@ -99,6 +96,8 @@ contract ForwarderV4 is IERC721Receiver, ERC1155Receiver, IForwarderV4 {
      * the sender to the forwarder itself
      */
     emit ForwarderDeposited(address(this), value, msg.data);
+    (bool success, ) = parentAddress.call{ value: value }('');
+    require(success, 'Flush failed');
   }
 
   /**
@@ -359,9 +358,9 @@ contract ForwarderV4 is IERC721Receiver, ERC1155Receiver, IForwarderV4 {
       return;
     }
 
+    emit ForwarderDeposited(msg.sender, value, msg.data);
     (bool success, ) = parentAddress.call{ value: value }('');
     require(success, 'Flush failed');
-    emit ForwarderDeposited(msg.sender, value, msg.data);
   }
 
   /**

--- a/contracts/TransferHelper.sol
+++ b/contracts/TransferHelper.sol
@@ -31,10 +31,6 @@ library TransferHelper {
     (bool success, bytes memory returndata) = token.call(
       abi.encodeWithSelector(0x23b872dd, from, to, value)
     );
-    Address.verifyCallResult(
-      success,
-      returndata,
-      'TransferHelper::transferFrom: transferFrom failed'
-    );
+    Address.verifyCallResult(success, returndata);
   }
 }

--- a/contracts/WalletFactory.sol
+++ b/contracts/WalletFactory.sol
@@ -4,7 +4,7 @@ import './WalletSimple.sol';
 import './CloneFactory.sol';
 
 contract WalletFactory is CloneFactory {
-  address public implementationAddress;
+  address public immutable implementationAddress;
 
   event WalletCreated(address newWalletAddress, address[] allowedSigners);
 

--- a/contracts/WalletFactory.sol
+++ b/contracts/WalletFactory.sol
@@ -19,7 +19,7 @@ contract WalletFactory is CloneFactory {
     bytes32 finalSalt = keccak256(abi.encodePacked(allowedSigners, salt));
 
     address payable clone = createClone(implementationAddress, finalSalt);
-    WalletSimple(clone).init(allowedSigners);
     emit WalletCreated(clone, allowedSigners);
+    WalletSimple(clone).init(allowedSigners);
   }
 }

--- a/contracts/WalletSimple.sol
+++ b/contracts/WalletSimple.sol
@@ -6,7 +6,7 @@ import './IForwarder.sol';
 
 /** ERC721, ERC1155 imports */
 import '@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol';
-import '@openzeppelin/contracts/token/ERC1155/utils/ERC1155Receiver.sol';
+import '@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol';
 import '@openzeppelin/contracts/utils/Strings.sol';
 
 /**
@@ -35,7 +35,7 @@ import '@openzeppelin/contracts/utils/Strings.sol';
  *
  *
  */
-contract WalletSimple is IERC721Receiver, ERC1155Receiver {
+contract WalletSimple is IERC721Receiver, ERC1155Holder {
   // Events
   event Deposited(address from, uint256 value, bytes data);
   event SafeModeActivated(address msgSender);
@@ -472,28 +472,28 @@ contract WalletSimple is IERC721Receiver, ERC1155Receiver {
   }
 
   /**
-   * @inheritdoc IERC1155Receiver
+   * @inheritdoc ERC1155Holder
    */
   function onERC1155Received(
     address _operator,
     address _from,
     uint256 id,
     uint256 value,
-    bytes calldata data
-  ) external virtual override returns (bytes4) {
+    bytes memory data
+  ) public virtual override returns (bytes4) {
     return this.onERC1155Received.selector;
   }
 
   /**
-   * @inheritdoc IERC1155Receiver
+   * @inheritdoc ERC1155Holder
    */
   function onERC1155BatchReceived(
     address _operator,
     address _from,
-    uint256[] calldata ids,
-    uint256[] calldata values,
-    bytes calldata data
-  ) external virtual override returns (bytes4) {
+    uint256[] memory ids,
+    uint256[] memory values,
+    bytes memory data
+  ) public virtual override returns (bytes4) {
     return this.onERC1155BatchReceived.selector;
   }
 

--- a/contracts/WalletSimple.sol
+++ b/contracts/WalletSimple.sol
@@ -123,19 +123,10 @@ contract WalletSimple is IERC721Receiver, ERC1155Holder {
   }
 
   /**
-   * Determine if an address is a signer on this wallet
-   * @param signer address to check
-   * returns boolean indicating whether address is signer or not
-   */
-  function isSigner(address signer) public view returns (bool) {
-    return signers[signer];
-  }
-
-  /**
    * Modifier that will execute internal code block only if the sender is an authorized signer on this wallet
    */
   modifier onlySigner() {
-    require(isSigner(msg.sender), 'Non-signer in onlySigner method');
+    require(signers[msg.sender], 'Non-signer in onlySigner method');
     _;
   }
 
@@ -439,7 +430,7 @@ contract WalletSimple is IERC721Receiver, ERC1155Holder {
     address otherSigner = recoverAddressFromSignature(operationHash, signature);
 
     // Verify if we are in safe mode. In safe mode, the wallet can only send to signers
-    require(!safeMode || isSigner(toAddress), 'External transfer in safe mode');
+    require(!safeMode || signers[toAddress], 'External transfer in safe mode');
 
     // Verify that the transaction has not expired
     require(expireTime >= block.timestamp, 'Transaction expired');
@@ -447,7 +438,7 @@ contract WalletSimple is IERC721Receiver, ERC1155Holder {
     // Try to insert the sequence ID. Will revert if the sequence id was invalid
     tryInsertSequenceId(sequenceId);
 
-    require(isSigner(otherSigner), 'Invalid signer');
+    require(signers[otherSigner], 'Invalid signer');
 
     require(otherSigner != msg.sender, 'Signers cannot be equal');
 

--- a/contracts/WalletSimple.sol
+++ b/contracts/WalletSimple.sol
@@ -180,14 +180,7 @@ contract WalletSimple is IERC721Receiver, ERC1155Holder {
   ) external onlySigner {
     // Verify the other signer
     bytes32 operationHash = keccak256(
-      abi.encodePacked(
-        getNetworkId(),
-        toAddress,
-        value,
-        data,
-        expireTime,
-        sequenceId
-      )
+      abi.encode(getNetworkId(), toAddress, value, data, expireTime, sequenceId)
     );
 
     address otherSigner = verifyMultiSig(
@@ -239,7 +232,7 @@ contract WalletSimple is IERC721Receiver, ERC1155Holder {
 
     // Verify the other signer
     bytes32 operationHash = keccak256(
-      abi.encodePacked(
+      abi.encode(
         getBatchNetworkId(),
         recipients,
         values,

--- a/contracts/WalletSimple.sol
+++ b/contracts/WalletSimple.sol
@@ -207,10 +207,6 @@ contract WalletSimple is IERC721Receiver, ERC1155Receiver {
       sequenceId
     );
 
-    // Success, send the transaction
-    (bool success, ) = toAddress.call{ value: value }(data);
-    require(success, 'Call execution failed');
-
     emit Transacted(
       msg.sender,
       otherSigner,
@@ -219,6 +215,10 @@ contract WalletSimple is IERC721Receiver, ERC1155Receiver {
       value,
       data
     );
+
+    // Success, send the transaction
+    (bool success, ) = toAddress.call{ value: value }(data);
+    require(success, 'Call execution failed');
   }
 
   /**
@@ -268,8 +268,8 @@ contract WalletSimple is IERC721Receiver, ERC1155Receiver {
       sequenceId
     );
 
-    batchTransfer(recipients, values);
     emit BatchTransacted(msg.sender, otherSigner, operationHash);
+    batchTransfer(recipients, values);
   }
 
   /**
@@ -286,10 +286,10 @@ contract WalletSimple is IERC721Receiver, ERC1155Receiver {
     for (uint256 i = 0; i < recipients.length; i++) {
       require(address(this).balance >= values[i], 'Insufficient funds');
 
+      emit BatchTransfer(msg.sender, recipients[i], values[i]);
+
       (bool success, ) = recipients[i].call{ value: values[i] }('');
       require(success, 'Call failed');
-
-      emit BatchTransfer(msg.sender, recipients[i], values[i]);
     }
   }
 

--- a/contracts/WalletSimple.sol
+++ b/contracts/WalletSimple.sol
@@ -553,7 +553,7 @@ contract WalletSimple is IERC721Receiver, ERC1155Holder {
    * greater than the minimum element in the window.
    * @param sequenceId to insert into array of stored ids
    */
-  function tryInsertSequenceId(uint256 sequenceId) private onlySigner {
+  function tryInsertSequenceId(uint256 sequenceId) private {
     // Keep a pointer to the lowest value element in the window
     uint256 lowestValueIndex = 0;
     // fetch recentSequenceIds into memory for function context to avoid unnecessary sloads

--- a/contracts/WalletSimple.sol
+++ b/contracts/WalletSimple.sol
@@ -282,7 +282,7 @@ contract WalletSimple is IERC721Receiver, ERC1155Holder {
   function batchTransfer(
     address[] calldata recipients,
     uint256[] calldata values
-  ) internal {
+  ) private {
     for (uint256 i = 0; i < recipients.length; i++) {
       require(address(this).balance >= values[i], 'Insufficient funds');
 

--- a/contracts/recoveryContracts/RecoveryWalletFactory.sol
+++ b/contracts/recoveryContracts/RecoveryWalletFactory.sol
@@ -4,7 +4,7 @@ import './RecoveryWalletSimple.sol';
 import '../CloneFactory.sol';
 
 contract RecoveryWalletFactory is CloneFactory {
-  address public implementationAddress;
+  address public immutable implementationAddress;
 
   constructor(address _implementationAddress) {
     implementationAddress = _implementationAddress;

--- a/contracts/recoveryContracts/RecoveryWalletSimple.sol
+++ b/contracts/recoveryContracts/RecoveryWalletSimple.sol
@@ -39,12 +39,7 @@ contract RecoveryWalletSimple is IERC721Receiver, ERC1155Receiver {
     require(!initialized, 'Contract already initialized');
     _;
   }
-
-  /**
-   * Gets called when a transaction is received with data that does not match any other method
-   */
-  fallback() external payable {}
-
+  
   /**
    * Gets called when a transaction is received with ether and no data
    */

--- a/contracts/recoveryContracts/RecoveryWalletSimple.sol
+++ b/contracts/recoveryContracts/RecoveryWalletSimple.sol
@@ -4,7 +4,7 @@ import '../IForwarder.sol';
 
 /** ERC721, ERC1155 imports */
 import '@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol';
-import '@openzeppelin/contracts/token/ERC1155/utils/ERC1155Receiver.sol';
+import '@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol';
 
 /**
  *
@@ -14,7 +14,7 @@ import '@openzeppelin/contracts/token/ERC1155/utils/ERC1155Receiver.sol';
  * Basic singleSig wallet designed to recover funds.
  *
  */
-contract RecoveryWalletSimple is IERC721Receiver, ERC1155Receiver {
+contract RecoveryWalletSimple is IERC721Receiver, ERC1155Holder {
   // Public fields
   address public signer;
   bool public initialized = false; // True if the contract has been initialized
@@ -39,7 +39,7 @@ contract RecoveryWalletSimple is IERC721Receiver, ERC1155Receiver {
     require(!initialized, 'Contract already initialized');
     _;
   }
-  
+
   /**
    * Gets called when a transaction is received with ether and no data
    */
@@ -170,28 +170,28 @@ contract RecoveryWalletSimple is IERC721Receiver, ERC1155Receiver {
   }
 
   /**
-   * @inheritdoc IERC1155Receiver
+   * @inheritdoc ERC1155Holder
    */
   function onERC1155Received(
     address _operator,
     address _from,
     uint256 id,
     uint256 value,
-    bytes calldata data
-  ) external virtual override returns (bytes4) {
+    bytes memory data
+  ) public virtual override returns (bytes4) {
     return this.onERC1155Received.selector;
   }
 
   /**
-   * @inheritdoc IERC1155Receiver
+   * @inheritdoc ERC1155Holder
    */
   function onERC1155BatchReceived(
     address _operator,
     address _from,
-    uint256[] calldata ids,
-    uint256[] calldata values,
-    bytes calldata data
-  ) external virtual override returns (bytes4) {
+    uint256[] memory ids,
+    uint256[] memory values,
+    bytes memory data
+  ) public virtual override returns (bytes4) {
     return this.onERC1155BatchReceived.selector;
   }
 }

--- a/contracts/test/MockERC1155.sol
+++ b/contracts/test/MockERC1155.sol
@@ -6,7 +6,7 @@ import '@openzeppelin/contracts/token/ERC1155/ERC1155.sol';
 import '@openzeppelin/contracts/access/Ownable.sol';
 
 contract MockERC1155 is ERC1155, Ownable {
-  constructor() ERC1155('https://app.bitgo-test.com/') {}
+  constructor() Ownable(msg.sender) ERC1155('https://app.bitgo-test.com/') {}
 
   function setURI(string memory newuri) public onlyOwner {
     _setURI(newuri);

--- a/contracts/test/ReentryForwarder.sol
+++ b/contracts/test/ReentryForwarder.sol
@@ -42,8 +42,8 @@ contract ReentryForwarder {
     address _from,
     uint256 id,
     uint256 value,
-    bytes calldata data
-  ) external returns (bytes4) {
+    bytes memory data
+  ) public returns (bytes4) {
     if (reentry) {
       (bool success, ) = forwarder.call(
         abi.encodeWithSignature(
@@ -64,10 +64,10 @@ contract ReentryForwarder {
   function onERC1155BatchReceived(
     address _operator,
     address _from,
-    uint256[] calldata ids,
-    uint256[] calldata values,
-    bytes calldata data
-  ) external returns (bytes4) {
+    uint256[] memory ids,
+    uint256[] memory values,
+    bytes memory data
+  ) public returns (bytes4) {
     if (reentry) {
       (bool success, ) = forwarder.call(
         abi.encodeWithSignature(

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -32,7 +32,11 @@ const config: HardhatUserConfig = {
       {
         version: '0.8.20',
         settings: {
-          evmVersion: 'paris'
+          evmVersion: 'paris',
+          optimizer: {
+            enabled: true,
+            runs: 1000
+          }
         }
       }
     ]

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -27,7 +27,16 @@ const {
 } = process.env;
 
 const config: HardhatUserConfig = {
-  solidity: '0.8.20',
+  solidity: {
+    compilers: [
+      {
+        version: '0.8.20',
+        settings: {
+          evmVersion: 'paris'
+        }
+      }
+    ]
+  },
   networks: {
     hardhat: {
       // If chainId is omitted, then there is no chain id validation

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "mocha": "^4.1.0",
     "q": "^1.5.1",
     "should": "^8.3.1",
-    "solc": "0.8.20"
+    "solc": "0.8.20",
+    "ethers": "^5.7.0"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.4",
@@ -64,7 +65,6 @@
     "eslint-plugin-prettier": "^3.4.1",
     "eslint-plugin-promise": "^5.2.0",
     "ethereum-waffle": "^3.4.0",
-    "ethers": "^5.5.4",
     "hardhat": "^2.17.4",
     "hardhat-gas-reporter": "^1.0.7",
     "prettier": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ethereum"
   ],
   "dependencies": {
-    "@openzeppelin/contracts": "4.9.0",
+    "@openzeppelin/contracts": "5.0.0",
     "@truffle/hdwallet-provider": "^2.0.0",
     "bignumber.js": "^9.0.0",
     "bluebird": "^3.3.5",

--- a/test/batcher.js
+++ b/test/batcher.js
@@ -530,7 +530,7 @@ describe('Batcher', () => {
         values: randVals,
         // costs roughly 40,000 gas to get to beginning of `distributeBatch`
         // and then another 10,000 gas for each subsequent iteration
-        gasLimit: 9e4
+        gasLimit: 10e4
       };
       await runTestBatcherDriver(params);
     });

--- a/test/forwarder.js
+++ b/test/forwarder.js
@@ -615,6 +615,7 @@ describe('Forwarder', function () {
     let reentryForwarderInstance;
     let forwarder;
     let tokenId = 1;
+    let tokenId1 = 2;
     const name = 'Non Fungible Token';
     const symbol = 'NFT';
     let owner;
@@ -701,7 +702,13 @@ describe('Forwarder', function () {
       await reentryForwarderInstance.setReentry(true);
 
       try {
-        await token1155.mintBatch(to, [tokenId], [amount], [], { from: owner });
+        await token1155.mintBatch(
+          to,
+          [tokenId, tokenId1],
+          [amount, amount],
+          [],
+          { from: owner }
+        );
       } catch (err) {
         assertVMException(
           err,

--- a/test/forwarderV4.js
+++ b/test/forwarderV4.js
@@ -773,6 +773,7 @@ describe('ForwarderV4', function () {
     let reentryForwarderInstance;
     let forwarder;
     let tokenId = 1;
+    let tokenId1 = 2;
     const name = 'Non Fungible Token';
     const symbol = 'NFT';
     let owner;
@@ -860,7 +861,13 @@ describe('ForwarderV4', function () {
       await reentryForwarderInstance.setReentry(true);
 
       try {
-        await token1155.mintBatch(to, [tokenId], [amount], [], { from: owner });
+        await token1155.mintBatch(
+          to,
+          [tokenId, tokenId1],
+          [amount, amount],
+          [],
+          { from: owner }
+        );
       } catch (err) {
         assertVMException(
           err,

--- a/test/gas.js
+++ b/test/gas.js
@@ -67,7 +67,7 @@ describe(`Wallet Operations Gas Usage`, function () {
       accounts[1],
       accounts[2]
     ]);
-    checkGasUsed(170677, transaction.receipt.gasUsed);
+    checkGasUsed(163180, transaction.receipt.gasUsed);
   });
 
   it('WalletSimple send [ @skip-on-coverage ]', async function () {
@@ -123,7 +123,7 @@ describe(`Wallet Operations Gas Usage`, function () {
       .plus(amount)
       .eq(destinationEndBalance)
       .should.be.true();
-    checkGasUsed(100214, transaction.receipt.gasUsed);
+    checkGasUsed(96455, transaction.receipt.gasUsed);
   });
 
   const sendBatchHelper = async (batchSize) => {
@@ -185,8 +185,8 @@ describe(`Wallet Operations Gas Usage`, function () {
 
   it('WalletSimple send batch [ @skip-on-coverage ]', async function () {
     const gasUsageByBatchSize = [
-      103143, 114458, 125772, 137086, 148413, 159692, 171042, 182344, 193659,
-      204962
+      98637, 108706, 118786, 128854, 138923, 148968, 159060, 169117, 179185,
+      189255
     ];
 
     for (let batchSize = 1; batchSize <= 10; batchSize++) {

--- a/test/gas.js
+++ b/test/gas.js
@@ -120,7 +120,7 @@ describe(`Wallet Operations Gas Usage`, function () {
       .plus(amount)
       .eq(destinationEndBalance)
       .should.be.true();
-    checkGasUsed(100347, transaction.receipt.gasUsed);
+    checkGasUsed(100271, transaction.receipt.gasUsed);
   });
 
   const sendBatchHelper = async (batchSize) => {
@@ -179,8 +179,8 @@ describe(`Wallet Operations Gas Usage`, function () {
 
   it('WalletSimple send batch [ @skip-on-coverage ]', async function () {
     const gasUsageByBatchSize = [
-      103101, 114416, 125730, 137044, 148370, 159650, 171000, 182302, 193617,
-      204920
+      103015, 114330, 125644, 136958, 148284, 159564, 170914, 182216, 193531,
+      204834
     ];
 
     for (let batchSize = 1; batchSize <= 10; batchSize++) {

--- a/test/gas.js
+++ b/test/gas.js
@@ -120,7 +120,7 @@ describe(`Wallet Operations Gas Usage`, function () {
       .plus(amount)
       .eq(destinationEndBalance)
       .should.be.true();
-    checkGasUsed(100620, transaction.receipt.gasUsed);
+    checkGasUsed(100347, transaction.receipt.gasUsed);
   });
 
   const sendBatchHelper = async (batchSize) => {
@@ -179,8 +179,8 @@ describe(`Wallet Operations Gas Usage`, function () {
 
   it('WalletSimple send batch [ @skip-on-coverage ]', async function () {
     const gasUsageByBatchSize = [
-      103362, 114677, 125991, 137341, 148631, 159971, 171261, 182563, 193878,
-      205181
+      103101, 114416, 125730, 137044, 148370, 159650, 171000, 182302, 193617,
+      204920
     ];
 
     for (let batchSize = 1; batchSize <= 10; batchSize++) {

--- a/test/gas.js
+++ b/test/gas.js
@@ -99,7 +99,10 @@ describe(`Wallet Operations Gas Usage`, function () {
       expireTime,
       sequenceId
     );
-    const sig = util.ecsign(operationHash, privateKeyForAccount(accounts[1]));
+    const sig = util.ecsign(
+      Buffer.from(operationHash.replace('0x', ''), 'hex'),
+      privateKeyForAccount(accounts[1])
+    );
 
     const destinationStartBalance = await web3.eth.getBalance(
       destinationAccount
@@ -120,7 +123,7 @@ describe(`Wallet Operations Gas Usage`, function () {
       .plus(amount)
       .eq(destinationEndBalance)
       .should.be.true();
-    checkGasUsed(100271, transaction.receipt.gasUsed);
+    checkGasUsed(100214, transaction.receipt.gasUsed);
   });
 
   const sendBatchHelper = async (batchSize) => {
@@ -155,7 +158,10 @@ describe(`Wallet Operations Gas Usage`, function () {
       expireTime,
       sequenceId
     );
-    const sig = util.ecsign(operationHash, privateKeyForAccount(accounts[1]));
+    const sig = util.ecsign(
+      Buffer.from(operationHash.replace('0x', ''), 'hex'),
+      privateKeyForAccount(accounts[1])
+    );
 
     const destinationStartBalance = await web3.eth.getBalance(destination);
 
@@ -179,8 +185,8 @@ describe(`Wallet Operations Gas Usage`, function () {
 
   it('WalletSimple send batch [ @skip-on-coverage ]', async function () {
     const gasUsageByBatchSize = [
-      103015, 114330, 125644, 136958, 148284, 159564, 170914, 182216, 193531,
-      204834
+      103143, 114458, 125772, 137086, 148413, 159692, 171042, 182344, 193659,
+      204962
     ];
 
     for (let batchSize = 1; batchSize <= 10; batchSize++) {

--- a/test/gas.js
+++ b/test/gas.js
@@ -67,7 +67,7 @@ describe(`Wallet Operations Gas Usage`, function () {
       accounts[1],
       accounts[2]
     ]);
-    checkGasUsed(171030, transaction.receipt.gasUsed);
+    checkGasUsed(170677, transaction.receipt.gasUsed);
   });
 
   it('WalletSimple send [ @skip-on-coverage ]', async function () {
@@ -120,8 +120,7 @@ describe(`Wallet Operations Gas Usage`, function () {
       .plus(amount)
       .eq(destinationEndBalance)
       .should.be.true();
-
-    checkGasUsed(100585, transaction.receipt.gasUsed);
+    checkGasUsed(100620, transaction.receipt.gasUsed);
   });
 
   const sendBatchHelper = async (batchSize) => {
@@ -180,8 +179,8 @@ describe(`Wallet Operations Gas Usage`, function () {
 
   it('WalletSimple send batch [ @skip-on-coverage ]', async function () {
     const gasUsageByBatchSize = [
-      103374, 114689, 126027, 137341, 148655, 159947, 171285, 182599, 193914,
-      205217
+      103362, 114677, 125991, 137341, 148631, 159971, 171261, 182563, 193878,
+      205181
     ];
 
     for (let batchSize = 1; batchSize <= 10; batchSize++) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -3,6 +3,7 @@ const util = require('ethereumjs-util');
 const BN = require('bn.js');
 const Promise = require('bluebird');
 const _ = require('lodash');
+const ethers = require('ethers');
 
 const Forwarder = artifacts.require('./Forwarder.sol');
 const ForwarderFactory = artifacts.require('./ForwarderFactory.sol');
@@ -61,17 +62,18 @@ exports.getSha3ForConfirmationTx = function (
   expireTime,
   sequenceId
 ) {
-  return abi.soliditySHA3(
+  const encoded = ethers.utils.defaultAbiCoder.encode(
     ['string', 'address', 'uint', 'bytes', 'uint', 'uint'],
     [
       prefix,
-      new BN(toAddress.replace('0x', ''), 16),
+      toAddress,
       amount,
       Buffer.from(data.replace('0x', ''), 'hex'),
       expireTime,
       sequenceId
     ]
   );
+  return ethers.utils.keccak256(encoded);
 };
 
 // Helper to get sha3 for solidity tightly-packed arguments
@@ -82,10 +84,11 @@ exports.getSha3ForBatchTx = function (
   expireTime,
   sequenceId
 ) {
-  return abi.soliditySHA3(
+  const encoded = ethers.utils.defaultAbiCoder.encode(
     ['string', 'address[]', 'uint[]', 'uint', 'uint'],
     [prefix, recipients, values, expireTime, sequenceId]
   );
+  return ethers.utils.keccak256(encoded);
 };
 
 // Helper to get token transactions sha3 for solidity tightly-packed arguments

--- a/test/walletFactory.js
+++ b/test/walletFactory.js
@@ -105,7 +105,10 @@ describe('WalletFactory', function () {
       expireTime,
       1
     );
-    const sig = util.ecsign(operationHash, privateKeyForAccount(accounts[1]));
+    const sig = util.ecsign(
+      Buffer.from(operationHash.replace('0x', ''), 'hex'),
+      privateKeyForAccount(accounts[1])
+    );
 
     await wallet.sendMultiSig(
       accounts[3].toLowerCase(),

--- a/test/walletSimple.js
+++ b/test/walletSimple.js
@@ -135,10 +135,10 @@ coins.forEach(
           isSafeMode.should.eql(false);
 
           const isSignerArray = await Promise.all([
-            wallet.isSigner.call(accounts[0]),
-            wallet.isSigner.call(accounts[1]),
-            wallet.isSigner.call(accounts[2]),
-            wallet.isSigner.call(accounts[3])
+            wallet.signers.call(accounts[0]),
+            wallet.signers.call(accounts[1]),
+            wallet.signers.call(accounts[2]),
+            wallet.signers.call(accounts[3])
           ]);
 
           isSignerArray.length.should.eql(4);

--- a/test/walletSimple.js
+++ b/test/walletSimple.js
@@ -342,7 +342,7 @@ coins.forEach(
           params.sequenceId
         );
         const sig = util.ecsign(
-          operationHash,
+          Buffer.from(operationHash.replace('0x', ''), 'hex'),
           privateKeyForAccount(params.otherSignerAddress)
         );
         await wallet.sendMultiSig(
@@ -399,7 +399,7 @@ coins.forEach(
           otherSignerArgs.sequenceId
         );
         const sig = util.ecsign(
-          operationHash,
+          Buffer.from(operationHash.replace('0x', ''), 'hex'),
           privateKeyForAccount(params.otherSignerAddress)
         );
 
@@ -519,7 +519,7 @@ coins.forEach(
             sequenceId
           );
           const sig = util.ecsign(
-            operationHash,
+            Buffer.from(operationHash.replace('0x', ''), 'hex'),
             privateKeyForAccount(accounts[1])
           );
 
@@ -564,10 +564,7 @@ coins.forEach(
         it('Stress test: 20 rounds of sendMultiSig', async function () {
           for (let round = 0; round < 20; round++) {
             const destinationAccount = accounts[2];
-            const amount = web3.utils.toWei(
-              web3.utils.toBN(_.random(1, 9)),
-              'ether'
-            );
+            const amount = web3.utils.toWei('1', 'ether');
             let expireTime = calculateFutureExpireTime(120);
             const data = util.addHexPrefix(
               crypto.randomBytes(20).toString('hex')
@@ -582,7 +579,7 @@ coins.forEach(
               sequenceId
             );
             const sig = util.ecsign(
-              operationHash,
+              Buffer.from(operationHash.replace('0x', ''), 'hex'),
               privateKeyForAccount(accounts[0])
             );
 
@@ -641,7 +638,7 @@ coins.forEach(
               sequenceId
             );
             const sig = util.ecsign(
-              operationHash,
+              Buffer.from(operationHash.replace('0x', ''), 'hex'),
               privateKeyForAccount(accounts[0])
             );
 
@@ -698,7 +695,7 @@ coins.forEach(
               sequenceId
             );
             const sig = util.ecsign(
-              operationHash,
+              Buffer.from(operationHash.replace('0x', ''), 'hex'),
               privateKeyForAccount(accounts[5 + (round % 5)])
             );
 
@@ -955,7 +952,7 @@ coins.forEach(
 
           // 2) sign tx with another account and modify the signature to make it invalid
           const sig = util.ecsign(
-            operationHash,
+            Buffer.from(operationHash.replace('0x', ''), 'hex'),
             privateKeyForAccount(otherSignerAddress)
           );
           sig.v = 0x666;
@@ -1053,7 +1050,7 @@ coins.forEach(
           otherSignerArgs.sequenceId
         );
         const sig = util.ecsign(
-          operationHash,
+          Buffer.from(operationHash.replace('0x', ''), 'hex'),
           privateKeyForAccount(params.otherSignerAddress)
         );
 
@@ -2532,7 +2529,7 @@ coins.forEach(
           );
 
           const sig = util.ecsign(
-            operationHash,
+            Buffer.from(operationHash.replace('0x', ''), 'hex'),
             privateKeyForAccount(accounts[1])
           );
           const signature = helpers.serializeSignature(sig);
@@ -2571,7 +2568,7 @@ coins.forEach(
             sequenceId
           );
           const sig = util.ecsign(
-            operationHash,
+            Buffer.from(operationHash.replace('0x', ''), 'hex'),
             privateKeyForAccount(accounts[1])
           );
           const signature = helpers.serializeSignature(sig);
@@ -2614,7 +2611,7 @@ coins.forEach(
           );
 
           const sig = util.ecsign(
-            operationHash,
+            Buffer.from(operationHash.replace('0x', ''), 'hex'),
             privateKeyForAccount(accounts[1])
           );
           const signature = helpers.serializeSignature(sig);
@@ -2653,7 +2650,7 @@ coins.forEach(
           );
 
           const sig = util.ecsign(
-            operationHash,
+            Buffer.from(operationHash.replace('0x', ''), 'hex'),
             privateKeyForAccount(accounts[1])
           );
           const signature = helpers.serializeSignature(sig);
@@ -2698,7 +2695,7 @@ coins.forEach(
           );
 
           const sig = util.ecsign(
-            operationHash,
+            Buffer.from(operationHash.replace('0x', ''), 'hex'),
             privateKeyForAccount(accounts[1])
           );
           const signature = helpers.serializeSignature(sig);
@@ -2728,7 +2725,7 @@ coins.forEach(
           let amount = web3.utils.toWei('1', 'ether');
           let toAddress = accounts[3];
           let tokenContractAddress = reentryInstance.address;
-          const operationHash = helpers.getSha3ForConfirmationTx(
+          const operationHash = helpers.getSha3ForConfirmationTokenTx(
             tokenPrefix,
             toAddress,
             amount,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5525,7 +5525,7 @@ ethers@^4.0.0-beta.1, ethers@^4.0.32, ethers@^4.0.40:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
-ethers@^5.0.1, ethers@^5.0.13, ethers@^5.0.2, ethers@^5.5.2, ethers@^5.5.4:
+ethers@^5.0.1, ethers@^5.0.13, ethers@^5.0.2, ethers@^5.5.2:
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.6.2.tgz#e75bac7f038c5e0fdde667dba62fc223924143a2"
   integrity sha512-EzGCbns24/Yluu7+ToWnMca3SXJ1Jk1BvWB7CCmVNxyOeM4LLvw2OLuIHhlkhQk1dtOcj9UMsdkxUh8RiG1dxQ==
@@ -5561,7 +5561,7 @@ ethers@^5.0.1, ethers@^5.0.13, ethers@^5.0.2, ethers@^5.5.2, ethers@^5.5.4:
     "@ethersproject/web" "5.6.0"
     "@ethersproject/wordlists" "5.6.0"
 
-ethers@^5.7.1:
+ethers@^5.7.0, ethers@^5.7.1:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1394,10 +1394,10 @@
     find-up "^4.1.0"
     fs-extra "^8.1.0"
 
-"@openzeppelin/contracts@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.0.tgz#683f33b6598970051bc5f0806fd8660da9e018dd"
-  integrity sha512-DUP74AFGKlic2sQb/CmgrN2aUPMFGxRrmCTUxLHsiU2RzwWqVuMPZBxiAyvlff6Pea77uylAX6B5x9W6evEbhA==
+"@openzeppelin/contracts@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.0.0.tgz#ee0e4b4564f101a5c4ee398cd4d73c0bd92b289c"
+  integrity sha512-bv2sdS6LKqVVMLI5+zqnNrNU/CA+6z6CmwFXm/MzmOPBRSO5reEJN7z0Gbzvs0/bv/MZZXNklubpwy3v2+azsw==
 
 "@openzeppelin/test-helpers@^0.5.15":
   version "0.5.15"


### PR DESCRIPTION
Commit 1: [fix BGB-03](https://github.com/BitGo/eth-multisig-v4/pull/120/commits/a8706b6e073b5644e228e55bdc85ef4b780cf0d2)
Commit 2: [fix RSC-02](https://github.com/BitGo/eth-multisig-v4/pull/120/commits/9305ad59b949b6cf73df1454413041dedbbb70da)
Commit 3: [fix BGB-02](https://github.com/BitGo/eth-multisig-v4/pull/120/commits/ccad0a378319485183c7e013afe23835fd65f2fe)
Commit 4: [fix GLOBAL-01](https://github.com/BitGo/eth-multisig-v4/pull/120/commits/c663442d2e47849c0010a77c0340dde2c13c9671) In this commit ERC1155Receiver contract was removed because it got depreciated in openzeppelin/contracts version 5.0.0. Instead ERC1155Holder contract is used for the same purpose.  The visibility of onERC1155Received and onERC1155BatchReceived method is changed to public because ERC1155Holder contract has these methods with public visibility
Commit 5: [fix WSG-03](https://github.com/BitGo/eth-multisig-v4/pull/120/commits/6fe7567986c49f67def47f084861629e4102cf34)
Commit 6: [fix BGB-01](https://github.com/BitGo/eth-multisig-v4/pull/120/commits/0d97e3850bacf8ddacdf7b7ff96fe65b315aa78d)
Commit 7: [fix WSG-02](https://github.com/BitGo/eth-multisig-v4/pull/120/commits/5b81368da18297f9c54f93f3c10fc332648520cc)
Commit 8: [fix WSG-01](https://github.com/BitGo/eth-multisig-v4/pull/120/commits/c46a116d5abebf0d46279f459b71944156a86760)
Commit 9: [fix BAT-02](https://github.com/BitGo/eth-multisig-v4/pull/120/commits/dc977afda65abbe71f6006e1c39e2d6c5df169ab). This change reverts the transaction if the sent out amount is not equal to the received eth amount. Some tests which are not relevant anymore are removed
Commit 10: [fix BAC-01](https://github.com/BitGo/eth-multisig-v4/pull/120/commits/ac1ec047e28a8e0dbb30301f46c8980164f29359). This change removes test to transfer ownership to address(0) as it is not relevant, because in the current flow ownership needs to be accepted by the new owner.
Commit 11: [fix WSG-06](https://github.com/BitGo/eth-multisig-v4/pull/120/commits/fed562abce87062e44d2e06383258cf94bb1f059). This change doesn't change abi.encodePacked in the sendMultiSigToken as it has not been highlighted as an issue.
Commit 12: [update optimizer runs](https://github.com/BitGo/eth-multisig-v4/pull/120/commits/1779f562903dee752821a797d8641974daea7353) Update optimizer runs in hardhat config

WIN-1733