### PR TITLE
fix: update key for batcher deployment

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -82,11 +82,19 @@ const config: HardhatUserConfig = {
     },
     eth: {
       url: `https://ethereum-rpc.publicnode.com`,
-      accounts: [`${PRIVATE_KEY_FOR_V4_CONTRACT_DEPLOYMENT}`]
+      accounts: [
+        `${PRIVATE_KEY_FOR_V4_CONTRACT_DEPLOYMENT}`,
+        `${PLACEHOLDER_KEY}`,
+        `${PRIVATE_KEY_FOR_BATCHER_CONTRACT_DEPLOYMENT}`
+      ]
     },
     hteth: {
-      url: `https://rpc.holesky.ethpandaops.io/`,
-      accounts: [`${PRIVATE_KEY_FOR_V4_CONTRACT_DEPLOYMENT_BACKUP}`]
+      url: `https://ethereum-holesky-rpc.publicnode.com`,
+      accounts: [
+        `${PRIVATE_KEY_FOR_V4_CONTRACT_DEPLOYMENT_BACKUP}`,
+        `${PLACEHOLDER_KEY}`,
+        `${PRIVATE_KEY_FOR_BATCHER_CONTRACT_DEPLOYMENT}`
+      ]
     },
     matic: {
       url: `https://polygon-rpc.com/`,


### PR DESCRIPTION
Ticket: COIN-3587

This PR intends to add key (PRIVATE_KEY_FOR_BATCHER_CONTRACT_DEPLOYMENT) for deploying batcher contract.
this was not present for EVM chains, probably because the new [workflow](https://github.com/BitGo/eth-multisig-v4/actions/workflows/deploy_batcher_contract.yml) was added in Sep 2024 [here](https://github.com/BitGo/eth-multisig-v4/pull/167).

The old way of deploying a batcher contract was via release.

Going forward, we need to update hardhat.config for chains where we intend to deploy updated batcher contract.