### PR TITLE
feat: add hoodi configs

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -96,7 +96,7 @@ const config: HardhatUserConfig = {
       ]
     },
     hteth: {
-      url: `https://ethereum-holesky-rpc.publicnode.com`,
+      url: `https://ethereum-hoodi-rpc.publicnode.com`,
       accounts: [
         `${PRIVATE_KEY_FOR_V4_CONTRACT_DEPLOYMENT_BACKUP}`,
         `${PLACEHOLDER_KEY}`,
@@ -478,7 +478,7 @@ const config: HardhatUserConfig = {
       //ethereum
       mainnet: `${ETHERSCAN_API_KEY}`,
       goerli: `${ETHERSCAN_API_KEY}`,
-      holesky: `${ETHERSCAN_API_KEY}`,
+      hoodi: `${ETHERSCAN_API_KEY}`,
       //polygon
       polygon: `${POLYGONSCAN_API_KEY}`,
       polygonAmoy: `${POLYGONSCAN_API_KEY}`,
@@ -547,11 +547,11 @@ const config: HardhatUserConfig = {
     },
     customChains: [
       {
-        network: 'holesky',
-        chainId: 17000,
+        network: 'hoodi',
+        chainId: 560048,
         urls: {
-          apiURL: 'https://api-holesky.etherscan.io/api',
-          browserURL: 'https://holesky.etherscan.io'
+          apiURL: 'https://api-hoodi.etherscan.io/api',
+          browserURL: 'https://hoodi.etherscan.io'
         }
       },
       {

--- a/scripts/chainConfig.ts
+++ b/scripts/chainConfig.ts
@@ -50,7 +50,7 @@ export async function getChainConfig(chainId: number): Promise<ChainConfig> {
 
   switch (chainId) {
     case 1:
-    case 17000:
+    case 560048:
     case 137:
     case 80002:
       forwarderContractName = 'ForwarderV4';


### PR DESCRIPTION
This pull request updates the configuration to replace references to the Ethereum Holesky testnet with the Ethereum Hoodi testnet across several files. The changes include modifications to URLs, chain IDs, and network names in the configuration and chain-handling logic.

### Updates to network configuration:

* [`hardhat.config.ts`]: Updated the RPC URL for the `hteth` network from Holesky to Hoodi (`https://ethereum-hoodi-rpc.publicnode.com`).
* [`hardhat.config.ts`]: Changed the custom chain configuration to use the Hoodi network name, chain ID `560048`, and updated the corresponding API and browser URLs.

### Updates to chain-handling logic:

* [`scripts/chainConfig.ts`]: Replaced the Holesky chain ID `17000` with Hoodi chain ID `560048` in the `getChainConfig` function to ensure proper handling of the Hoodi network.

Ticket: COIN-4802