### PR TITLE
fix: normalize eth_estimateGas for Hardhat on hpp

### DIFF
--- a/config/hppHardhatEstimateGasFix.ts
+++ b/config/hppHardhatEstimateGasFix.ts
@@ -1,0 +1,70 @@
+/**
+ * HPP mainnet RPC returns "contract creation code storage out of gas" for eth_estimateGas when
+ * the request includes gasLimit / fee fields from Hardhat+ethers deploy tx shaping.
+ * Strip those fields at the provider layer for HPP mainnet only (matches minimal curl).
+ * hardhat-ethers uses provider.send("eth_estimateGas", [...]), not request().
+ */
+import { extendEnvironment } from 'hardhat/config';
+
+/** Hardhat network name for HPP mainnet only (`thpp` testnet does not need this). */
+const HPP_MAINNET_HARDHAT_NETWORK = 'hpp';
+
+function stripGasFieldsFromEstimateTx(
+  tx: Record<string, unknown>
+): Record<string, unknown> {
+  const out = { ...tx };
+  delete out.gas;
+  delete out.gasLimit;
+  delete out.gasPrice;
+  delete out.maxFeePerGas;
+  delete out.maxPriorityFeePerGas;
+  delete out.type;
+  return out;
+}
+
+extendEnvironment((hre) => {
+  if (hre.network.name !== HPP_MAINNET_HARDHAT_NETWORK) {
+    return;
+  }
+  const provider = hre.network.provider as {
+    request(args: { method: string; params?: unknown[] }): Promise<unknown>;
+    send(method: string, params?: unknown[]): Promise<unknown>;
+  };
+
+  const origSend = provider.send.bind(provider);
+  provider.send = async (method: string, params?: unknown[]) => {
+    if (
+      method === 'eth_estimateGas' &&
+      Array.isArray(params) &&
+      params[0] !== null &&
+      typeof params[0] === 'object' &&
+      !Array.isArray(params[0])
+    ) {
+      const tx = stripGasFieldsFromEstimateTx(
+        params[0] as Record<string, unknown>
+      );
+      return origSend(method, [tx, ...params.slice(1)]);
+    }
+    return origSend(method, params);
+  };
+
+  const origRequest = provider.request.bind(provider);
+  provider.request = async (args) => {
+    if (
+      args.method === 'eth_estimateGas' &&
+      Array.isArray(args.params) &&
+      args.params[0] !== null &&
+      typeof args.params[0] === 'object' &&
+      !Array.isArray(args.params[0])
+    ) {
+      const tx = stripGasFieldsFromEstimateTx(
+        args.params[0] as Record<string, unknown>
+      );
+      return origRequest({
+        ...args,
+        params: [tx, ...args.params.slice(1)]
+      });
+    }
+    return origRequest(args);
+  };
+});

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,5 +1,6 @@
 import * as dotenv from 'dotenv';
 dotenv.config();
+import './config/hppHardhatEstimateGasFix';
 import { HardhatUserConfig } from 'hardhat/config';
 import '@nomicfoundation/hardhat-toolbox';
 import '@nomicfoundation/hardhat-verify';


### PR DESCRIPTION
## Summary

Fixes failed **`eth_estimateGas`** during Hardhat contract deploys on **HPP mainnet** (`--network hpp`) when the estimate request includes gas / EIP-1559 fields from Hardhat + ethers. The hook normalizes the RPC payload to match a minimal `{ from, data, … }` estimate (same idea as a minimal `curl`).

## Problem

On HPP mainnet, **`eth_estimateGas`** could fail with **`contract creation code storage out of gas`** when the transaction object included fields such as `gasLimit`, `gasPrice`, `maxFeePerGas`, `maxPriorityFeePerGas`, or `type`. The same bytecode could estimate successfully when those fields were omitted.

`@nomicfoundation/hardhat-ethers` uses **`provider.send("eth_estimateGas", [...])`**, so adjusting only **`request()`** is not sufficient.

## Solution

- **`config/hppHardhatEstimateGasFix.ts`**: `extendEnvironment` wraps **`send`** and **`request`** when **`hre.network.name === 'hpp'`** (HPP **mainnet** only). For **`eth_estimateGas`**, strip: `gas`, `gasLimit`, `gasPrice`, `maxFeePerGas`, `maxPriorityFeePerGas`, `type` before forwarding.
- **`hardhat.config.ts`**: import the module right after `dotenv.config()` so it loads for all Hardhat entrypoints.

**HPP Sepolia (`thpp`) is unchanged** — the workaround is not applied there.

Actual transaction broadcast / deploy txs are unchanged; only the **estimateGas** RPC shape is adjusted.

 Ticket: CGARD-454