### PR TITLE
fix: raise deploy gas limit for V4 contract CREATE

### DIFF
--- a/scripts/chainConfig.ts
+++ b/scripts/chainConfig.ts
@@ -378,6 +378,10 @@ export async function getChainConfig(chainId: number): Promise<ChainConfig> {
       break;
   }
 
+  if (chainId === CHAIN_IDS.HPP) {
+    gasParams = { ...gasParams, gasLimit: 16_000_000 };
+  }
+
   return {
     walletImplementationContractName,
     walletFactoryContractName,


### PR DESCRIPTION

Raise **`gasLimit`** for **HPP mainnet** (`CHAIN_IDS.HPP`) in `getChainConfig` so V4 deploy (`scripts/deploy.ts`) contract CREATEs.


Ticket: CGD-190

https://explorer.hpp.io/address/0x22aF3338ea896fB9ab16B068be60d12EbC1aDF08?tab=txs

<img width="2828" height="1488" alt="image" src="https://github.com/user-attachments/assets/96287d18-c11f-4380-872b-5a54791d146b" />
