### PR TITLE
fix: raise HPP mainnet deploy gasLimit to 60M

### DIFF
--- a/scripts/chainConfig.ts
+++ b/scripts/chainConfig.ts
@@ -379,7 +379,7 @@ export async function getChainConfig(chainId: number): Promise<ChainConfig> {
   }
 
   if (chainId === CHAIN_IDS.HPP) {
-    gasParams = { ...gasParams, gasLimit: 16_000_000 };
+    gasParams = { ...gasParams, gasLimit: 60_000_000 };
   }
 
   return {


### PR DESCRIPTION

Setting 60M provides headroom above the worst observed gas usage (~11.35M on Apr 21 2026) while staying well within HPP's block gas limit (~1.1 quadrillion).

verified locally: 
https://explorer.hpp.io/address/0x99dA2D8CA42E0dC33FaD96D9B3595DfE196aE341?tab=txs
https://explorer.hpp.io/address/0xd01774E2E0dA019fbE61d30d6aa1abC5794F7b6F?tab=txs

Ticket: CGD-190