### PR TITLE
feat: add Robinhood Chain (hoodeth) mainnet contract deployment config

### DIFF
--- a/config/chainIds.ts
+++ b/config/chainIds.ts
@@ -60,7 +60,7 @@ export const CHAIN_IDS = {
   HPP: 190415,
   XTZEVM: 42793,
   H: 6985385,
-  HOODETH: 999999, //TODO: update with correct mainnet chain ID when available
+  HOODETH: 4663,
   INKETH: 57073,
   HEMIETH: 43111,
   ABSTRACTETH: 2741,

--- a/deployUtils.ts
+++ b/deployUtils.ts
@@ -3,8 +3,23 @@ import fs from 'fs';
 import { BaseContract, getCreateAddress } from 'ethers';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { verifyOnCustomEtherscan } from './scripts/customContractVerifier';
+import { CHAIN_IDS } from './config/chainIds';
 
 const OUTPUT_FILE = 'output.json';
+
+// Per-chain verification overrides for chains with slow block times or restricted explorers.
+// All other chains use the defaults in VERIFICATION_CONFIG.
+const CHAIN_VERIFICATION_OVERRIDES: Partial<
+  Record<
+    number,
+    {
+      confirmationBlocks: number;
+      maxRetries: number;
+    }
+  >
+> = {
+  [CHAIN_IDS.HOODETH]: { confirmationBlocks: 2, maxRetries: 2 }
+};
 
 // Balance check configuration
 /**
@@ -461,11 +476,21 @@ export async function waitAndVerify(
     throw new Error(errorMsg);
   }
 
+  const chainId = hre.network?.config?.chainId;
+  const override = chainId ? CHAIN_VERIFICATION_OVERRIDES[chainId] : undefined;
+  const confirmationBlocks =
+    override?.confirmationBlocks ?? VERIFICATION_CONFIG.CONFIRMATION_BLOCKS;
+  const maxRetries = override?.maxRetries ?? VERIFICATION_CONFIG.MAX_RETRIES;
+
   // Wait for block confirmations
-  const contractAddress = await waitForConfirmations(contract, contractName);
+  const contractAddress = await waitForConfirmations(
+    contract,
+    contractName,
+    confirmationBlocks
+  );
 
   // Perform verification with retry logic
-  for (let attempt = 1; attempt <= VERIFICATION_CONFIG.MAX_RETRIES; attempt++) {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
     logger.info(`Verification attempt #${attempt} for ${contractName}...`);
 
     try {
@@ -490,7 +515,7 @@ export async function waitAndVerify(
     }
 
     // If we get here, verification failed and we should retry
-    if (attempt < VERIFICATION_CONFIG.MAX_RETRIES) {
+    if (attempt < maxRetries) {
       const delaySeconds = VERIFICATION_CONFIG.RETRY_DELAY_MS / 1000;
       logger.info(`Waiting ${delaySeconds} seconds before retrying...`);
       await delay(VERIFICATION_CONFIG.RETRY_DELAY_MS);

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -931,7 +931,8 @@ const config: HardhatUserConfig = {
       ]
     },
     hoodeth: {
-      url: 'https://rpc.testnet.chain.robinhood.com', // TODO: update to mainnet RPC when available
+      url: 'https://ac23019b22f1ae5a.offchainlabs.com/rpc/a6186cb065b52ca24da0d197e33b303c',
+      chainId: CHAIN_IDS.HOODETH,
       accounts: [
         `${PRIVATE_KEY_FOR_V4_CONTRACT_DEPLOYMENT}`,
         `${PLACEHOLDER_KEY}`,
@@ -1977,8 +1978,8 @@ const config: HardhatUserConfig = {
         network: 'hoodethMainnet',
         chainId: CHAIN_IDS.HOODETH,
         urls: {
-          apiURL: 'https://explorer.testnet.chain.robinhood.com/api', // TODO: update to mainnet explorer API when available
-          browserURL: 'https://explorer.testnet.chain.robinhood.com' // TODO: update to mainnet explorer when available
+          apiURL: 'https://8crv4vmq6tiu1yqr.blockscout.com/api',
+          browserURL: 'https://8crv4vmq6tiu1yqr.blockscout.com'
         }
       },
       {

--- a/scripts/chainConfig.ts
+++ b/scripts/chainConfig.ts
@@ -363,10 +363,15 @@ export async function getChainConfig(chainId: number): Promise<ChainConfig> {
     case CHAIN_IDS.UNICHAIN_TESTNET:
     case CHAIN_IDS.HPP:
     case CHAIN_IDS.HPP_TESTNET:
-    case CHAIN_IDS.HOODETH:
     case CHAIN_IDS.HOODETH_TESTNET:
     case CHAIN_IDS.INKETH:
     case CHAIN_IDS.INKETH_TESTNET:
+      forwarderContractName = 'ForwarderV4';
+      forwarderFactoryContractName = 'ForwarderFactoryV4';
+      break;
+
+    case CHAIN_IDS.HOODETH:
+      gasParams = { ...gasParams, gasLimit: 50_000_000 };
       forwarderContractName = 'ForwarderV4';
       forwarderFactoryContractName = 'ForwarderFactoryV4';
       break;


### PR DESCRIPTION
## Summary
- Updates `HOODETH` chain ID from placeholder `999999` to correct mainnet value `4663` (Robinhood Chain, ArbOS 51)
- Adds `HOODETH` deploy gas config: `gasLimit: 50M`, `ForwarderV4`/`ForwarderFactoryV4`
- Updates `hoodeth` network in `hardhat.config.ts` with mainnet RPC, `chainId`, and Blockscout mainnet explorer URLs
- Adds `CHAIN_VERIFICATION_OVERRIDES` in `deployUtils.ts` for hoodeth: 2 block confirmations and 2 verification retries — Robinhood Chain is a low-activity private chain with ~98 min average block time; the defaults (5 confirmations, 10 retries × 60s) would cause CI timeouts

## Deployed Addresses (Mainnet: hoodeth — Robinhood Chain, Chain ID: 4663)
- WalletSimple:       0xE39602d6D3570dE50721cb98C0f1813F956E35bB
- WalletFactory:      0x86835565aD0aA35e83FEb4a0F6e4F43E6Ffa27b8
- ForwarderV4:        0x51eF284caAE2269FB7f9b9e118147ECc221dC680
- ForwarderFactoryV4: 0xDA4300c74F501058bA6B971f724BdC86846c42A7
- Batcher:            0x3BC098a2EDE9835ed6f4271851b15f6a1B8C6249

deployment logs : https://docs.google.com/document/d/1hZWm1LRX0ObeZLU5v6yLu43RqiyusLjy-81zPa0lHpg/edit?usp=sharing

## Gas Usage Analysis — Hoodeth Mainnet Deployment

| Contract | Gas Used | Gas Limit | Headroom |
|---|---|---|---|
| WalletSimple | 2,822,165 | 50,000,000 | **17.7×** |
| WalletFactory | 376,918 | 50,000,000 | 132.7× |
| ForwarderV4 | 2,461,667 | 50,000,000 | 20.3× |
| ForwarderFactoryV4 | 402,013 | 50,000,000 | 124.4× |

The configured `gasLimit` of **50M** provides **17.7× headroom** over the largest contract (WalletSimple at ~2.8M gas). This accounts for L1 data fee volatility on Arbitrum-based rollups, where the total `gasUsed` includes a variable L1 data posting component driven by Ethereum mainnet conditions.


## Test plan
- [x] V4 contracts deployed and confirmed on chain at expected nonces (0-3) : [transactions link](https://8crv4vmq6tiu1yqr.blockscout.com/address/0xf7B99A38Cf6c4CE8Ffa5eB209f2A0C8882b92A0f?tab=txs)
- [x] Batcher deployed and confirmed on chain : [transactions link](https://8crv4vmq6tiu1yqr.blockscout.com/address/0x16763e10C606598ccA57a4B2D40deaac1C930230?tab=txs)
- [x] Deploy script completes within CI time limits with 2 confirmations + 2 retries
- [x] No impact on existing chain deployments (all other chains use default 5 confirmations, 10 retries)

Ticket: CGD-976
