### PR TITLE
feat: fix gas config for arcusdc mainnet deployment

### DIFF
--- a/scripts/chainConfig.ts
+++ b/scripts/chainConfig.ts
@@ -331,9 +331,9 @@ export async function getChainConfig(chainId: number): Promise<ChainConfig> {
     case CHAIN_IDS.ARCUSDC_TESTNET:
     case CHAIN_IDS.ARCUSDC:
       gasParams = {
-        maxFeePerGas: feeData.gasPrice!,
-        maxPriorityFeePerGas: feeData.gasPrice!,
-        gasLimit: 30_000_000
+        maxFeePerGas: feeData.maxFeePerGas ?? feeData.gasPrice!,
+        maxPriorityFeePerGas: feeData.maxPriorityFeePerGas ?? feeData.gasPrice!,
+        gasLimit: 3_000_000
       };
       forwarderContractName = 'ForwarderV4';
       forwarderFactoryContractName = 'ForwarderFactoryV4';


### PR DESCRIPTION
## Problem
Arc mainnet contract deployment was failing due to incorrect gas configuration:
- `gasPrice` was used for EIP-1559 params instead of `maxFeePerGas`/`maxPriorityFeePerGas`
- `gasLimit` of `30_000_000` exceeded Arc's per-transaction limit, causing `gas limit too high` errors

## Fix
- Use correct EIP-1559 fee params (`maxFeePerGas ?? gasPrice` fallback)
- Lower `gasLimit` from `30_000_000` to `3_000_000` (actual gas per contract is ~500K on Arc)

## Deployed Addresses (Arc Mainnet - Partial)

| Contract | Address |
| --- | --- |
| WalletSimple | `0x9f38448CB0E1C557E1013a07E8e24eC21c612bEE` |
| WalletFactory | `0x53c30a8B22a8c707ff10022616Accb287EF69Dd3` |
| ForwarderV4 | `0x720fd3Cb4C0e857fe37AEF59A267CBE14975a5B6` |
| ForwarderFactoryV4 | Pending |
| Batcher | `0x4a06df1f042e0D3e462EC809fcD6C86610627C56` |

Linear: https://linear.app/bitgo/issue/CECHO-1414/arc-mainnet-contract-changes