### PR TITLE
fix(arcusdc): hardcode mainnet RPC URL for CI deployment

### DIFF
--- a/.github/workflows/deploy_and_release.yml
+++ b/.github/workflows/deploy_and_release.yml
@@ -69,7 +69,6 @@ jobs:
           MEGAETH_EXPLORER_API_KEY: ${{ secrets.MEGAETH_EXPLORER_API_KEY }}
           HBAREVM_EXPLORER_API_KEY: ${{ secrets.HBAREVM_EXPLORER_API_KEY }}
           ARCUSDC_EXPLORER_API_KEY: ${{ secrets.ARCUSDC_EXPLORER_API_KEY }}
-          ARCUSDC_RPC_URL: ${{ secrets.ARCUSDC_RPC_URL }}
           opBNB_EXPLORER_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
 
   get-network:
@@ -185,7 +184,6 @@ jobs:
           HBAREVM_EXPLORER_API_KEY: ${{ secrets.HBAREVM_EXPLORER_API_KEY }}
           opBNB_EXPLORER_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
           ARCUSDC_EXPLORER_API_KEY: ${{ secrets.ARCUSDC_EXPLORER_API_KEY }}
-          ARCUSDC_RPC_URL: ${{ secrets.ARCUSDC_RPC_URL }}
 
       - name: Update release notes
         uses: actions/github-script@v6
@@ -283,7 +281,6 @@ jobs:
           MEGAETH_EXPLORER_API_KEY: ${{ secrets.MEGAETH_EXPLORER_API_KEY }}
           HBAREVM_EXPLORER_API_KEY: ${{ secrets.HBAREVM_EXPLORER_API_KEY }}
           ARCUSDC_EXPLORER_API_KEY: ${{ secrets.ARCUSDC_EXPLORER_API_KEY }}
-          ARCUSDC_RPC_URL: ${{ secrets.ARCUSDC_RPC_URL }}
           opBNB_EXPLORER_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
 
       - name: Update release notes

--- a/.github/workflows/deploy_batcher_contract.yml
+++ b/.github/workflows/deploy_batcher_contract.yml
@@ -68,7 +68,6 @@ jobs:
           MEGAETH_EXPLORER_API_KEY: ${{ secrets.MEGAETH_EXPLORER_API_KEY }}
           HBAREVM_EXPLORER_API_KEY: ${{ secrets.HBAREVM_EXPLORER_API_KEY }}
           ARCUSDC_EXPLORER_API_KEY: ${{ secrets.ARCUSDC_EXPLORER_API_KEY }}
-          ARCUSDC_RPC_URL: ${{ secrets.ARCUSDC_RPC_URL }}
   get-network:
     runs-on: ubuntu-latest
     needs: [lint-and-test]
@@ -176,7 +175,6 @@ jobs:
           MEGAETH_EXPLORER_API_KEY: ${{ secrets.MEGAETH_EXPLORER_API_KEY }}
           HBAREVM_EXPLORER_API_KEY: ${{ secrets.HBAREVM_EXPLORER_API_KEY }}
           ARCUSDC_EXPLORER_API_KEY: ${{ secrets.ARCUSDC_EXPLORER_API_KEY }}
-          ARCUSDC_RPC_URL: ${{ secrets.ARCUSDC_RPC_URL }}
       - name: Update release notes
         uses: actions/github-script@v7
         with:
@@ -250,7 +248,6 @@ jobs:
           MEGAETH_EXPLORER_API_KEY: ${{ secrets.MEGAETH_EXPLORER_API_KEY }}
           HBAREVM_EXPLORER_API_KEY: ${{ secrets.HBAREVM_EXPLORER_API_KEY }}
           ARCUSDC_EXPLORER_API_KEY: ${{ secrets.ARCUSDC_EXPLORER_API_KEY }}
-          ARCUSDC_RPC_URL: ${{ secrets.ARCUSDC_RPC_URL }}
       - name: Update release notes
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -71,5 +71,4 @@ jobs:
           KAIA_EXPLORER_API_KEY: ${{ secrets.KAIA_EXPLORER_API_KEY }}
           IRYS_EXPLORER_API_KEY: ${{ secrets.IRYS_EXPLORER_API_KEY }}
           IP_EXPLORER_API_KEY: ${{ secrets.IP_EXPLORER_API_KEY }}
-          ARCUSDC_RPC_URL: ${{ secrets.ARCUSDC_RPC_URL }}
       - run: npm run lint

--- a/.github/workflows/update_transfer_gas_limit.yaml
+++ b/.github/workflows/update_transfer_gas_limit.yaml
@@ -109,4 +109,3 @@ jobs:
           SEIEVM_EXPLORER_API_KEY: ${{ secrets.SEIEVM_EXPLORER_API_KEY }}
           KAIA_EXPLORER_API_KEY: ${{ secrets.KAIA_EXPLORER_API_KEY }}
           IP_EXPLORER_API_KEY: ${{ secrets.IP_EXPLORER_API_KEY }}
-          ARCUSDC_RPC_URL: ${{ secrets.ARCUSDC_RPC_URL }}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -59,7 +59,6 @@ const {
   FLOW_EXPLORER_API_KEY,
   HBAREVM_EXPLORER_API_KEY,
   ARCUSDC_EXPLORER_API_KEY,
-  ARCUSDC_RPC_URL,
   DOGEOS_EXPLORER_API_KEY
 } = process.env;
 
@@ -869,7 +868,7 @@ const config: HardhatUserConfig = {
       ]
     },
     arcusdc: {
-      url: `${ARCUSDC_RPC_URL}`,
+      url: 'https://rpc.blockdaemon.mainnet.arc.io',
       accounts: [
         `${PRIVATE_KEY_FOR_V4_CONTRACT_DEPLOYMENT}`,
         `${PLACEHOLDER_KEY}`,


### PR DESCRIPTION
## Summary
- Hardcode Arc mainnet RPC URL (`https://rpc.blockdaemon.mainnet.arc.io`) in `hardhat.config.ts` for the `arcusdc` network
- Remove unused `ARCUSDC_RPC_URL` env dependency
- Fixes `v4.0-arcusdc` deploy failure: `HardhatError: HH117: Empty string for network or forking URL`

## Context
The `deploy-to-prod` job failed because `ARCUSDC_RPC_URL` was referenced in Hardhat config but never set as a GitHub secret. Other EVM chains (chiliz, inketh, tarcusdc) use hardcoded public RPC URLs instead.

## Test plan
- [ ] Merge PR
- [ ] Re-run or re-publish `v4.0-arcusdc` release deploy workflow
- [ ] Confirm `deploy-to-prod` passes RPC init and begins contract deployment
- [ ] Ensure deployer wallet has sufficient USDC on Arc mainnet for gas


Made with [Cursor](https://cursor.com)