### PR TITLE
Add workflow to transfer Batcher ownership (COINS-1281)

### DIFF
--- a/.github/workflows/transfer_batcher_ownership.yaml
+++ b/.github/workflows/transfer_batcher_ownership.yaml
@@ -1,0 +1,111 @@
+name: Transfer Batcher Ownership
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: true
+        type: choice
+        options:
+          - testnet
+          - mainnet
+      network:
+        description: 'Hardhat network (e.g., tmorpheth, morpheth)'
+        required: true
+        type: string
+      batcher_address:
+        description: 'Batcher contract address (required)'
+        required: true
+        default: ''
+        type: string
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approval summary
+        run: |
+          cat <<EOF >> "$GITHUB_STEP_SUMMARY"
+          ### Transfer Batcher Ownership — Approval Summary
+
+          - Environment: ${{ inputs.environment }}
+          - Network: ${{ inputs.network }}
+          - Batcher Address: \`${{ inputs.batcher_address }}\`
+
+          Actions to be performed after approval:
+          - Run: npm run transfer-batcher-ownership -- ${{ inputs.network }}
+          - Call transferOwnership(newOwner) on the Batcher contract at the above address
+          - Use signer index 2 (same as deploy script)
+          - newOwner is the hardcoded NEW_OWNER_ADDRESS constant in scripts/transferBatcherOwnership.ts,
+            cross-checked against the BATCHER_NEW_OWNER_ADDRESS secret -- not a workflow input
+
+          This only sets pendingOwner(); owner() does not change until the new
+          custody wallet calls acceptOwnership() separately. The current owner
+          retains full owner privileges until that happens.
+
+          > Approve only if the Batcher address is correct.
+          EOF
+  run-transfer:
+    needs: preview
+    runs-on: ubuntu-latest
+    environment: '${{ inputs.environment }}'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: 'npm'
+      - run: npm install
+      - name: Run transfer ownership script
+        run: |
+          export BATCHER_ADDRESS="${{ inputs.batcher_address }}"
+          npm run transfer-batcher-ownership -- ${{ inputs.network }}
+        env:
+          BATCHER_NEW_OWNER_ADDRESS: ${{ secrets.BATCHER_NEW_OWNER_ADDRESS }}
+          MAINNET_PRIVATE_KEY_FOR_CONTRACT_DEPLOYMENT: ${{ secrets.MAINNET_PRIVATE_KEY_FOR_CONTRACT_DEPLOYMENT }}
+          TESTNET_PRIVATE_KEY_FOR_CONTRACT_DEPLOYMENT: ${{ secrets.TESTNET_PRIVATE_KEY_FOR_CONTRACT_DEPLOYMENT }}
+          PRIVATE_KEY_FOR_V4_CONTRACT_DEPLOYMENT: ${{ secrets.PRIVATE_KEY_FOR_V4_CONTRACT_DEPLOYMENT }}
+          PRIVATE_KEY_FOR_V4_CONTRACT_DEPLOYMENT_BACKUP: ${{ secrets.PRIVATE_KEY_FOR_V4_CONTRACT_DEPLOYMENT_BACKUP }}
+          PRIVATE_KEY_FOR_V1_WALLET_CONTRACT_DEPLOYMENT: ${{ secrets.PRIVATE_KEY_FOR_V1_WALLET_CONTRACT_DEPLOYMENT }}
+          PRIVATE_KEY_FOR_BATCHER_CONTRACT_DEPLOYMENT: ${{ secrets.PRIVATE_KEY_FOR_BATCHER_CONTRACT_DEPLOYMENT }}
+          QUICKNODE_ETH_MAINNET_API_KEY: ${{ secrets.QUICKNODE_ETH_MAINNET_API_KEY }}
+          QUICKNODE_ETH_HOLESKY_API_KEY: ${{ secrets.QUICKNODE_ETH_HOLESKY_API_KEY }}
+          QUICKNODE_ARBITRUM_SEPOLIA_API_KEY: ${{ secrets.QUICKNODE_ARBITRUM_SEPOLIA_API_KEY }}
+          QUICKNODE_PLASMA_API_KEY: ${{ secrets.QUICKNODE_PLASMA_API_KEY }}
+          SOMNIA_TESTNET_API_KEY: ${{ secrets.SOMNIA_TESTNET_API_KEY }}
+          MONAD_MAINNET_API_KEY: ${{ secrets.MONAD_MAINNET_API_KEY }}
+          MEGAETH_TESTNET_API_KEY: ${{ secrets.MEGAETH_TESTNET_API_KEY }}
+          QUICKNODE_ARBITRUM_ONE_API_KEY: ${{ secrets.QUICKNODE_ARBITRUM_ONE_API_KEY }}
+          QUICKNODE_OPTIMISM_SEPOLIA_API_KEY: ${{ secrets.QUICKNODE_OPTIMISM_SEPOLIA_API_KEY }}
+          QUICKNODE_OPTIMISM_API_KEY: ${{ secrets.QUICKNODE_OPTIMISM_API_KEY }}
+          QUICKNODE_ZKSYNC_SEPOLIA_API_KEY: ${{ secrets.QUICKNODE_ZKSYNC_SEPOLIA_API_KEY }}
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+          ALCHEMY_POLYGON_API_KEY: ${{ secrets.ALCHEMY_POLYGON_API_KEY }}
+          POLYGONSCAN_API_KEY: ${{ secrets.POLYGONSCAN_API_KEY }}
+          BSCSCAN_API_KEY: ${{ secrets.BSCSCAN_API_KEY }}
+          ARBISCAN_API_KEY: ${{ secrets.ARBISCAN_API_KEY }}
+          OPTIMISTIC_ETHERSCAN_API_KEY: ${{ secrets.OPTIMISTIC_ETHERSCAN_API_KEY }}
+          ZKSYNC_EXPLORER_API_KEY: ${{ secrets.ZKSYNC_EXPLORER_API_KEY }}
+          BASESCAN_API_KEY: ${{ secrets.BASESCAN_API_KEY }}
+          BEPOLIA_BERA_EXPLORER_API_KEY: ${{ secrets.BEPOLIA_BERA_EXPLORER_API_KEY }}
+          BERA_EXPLORER_API_KEY: ${{ secrets.BERA_EXPLORER_API_KEY }}
+          OAS_EXPLORER_API_KEY: ${{ secrets.OAS_EXPLORER_API_KEY }}
+          CORE_DAO_TESTNET_EXPLORER_API_KEY: ${{ secrets.CORE_DAO_TESTNET_EXPLORER_API_KEY }}
+          CORE_DAO_MAINNET_EXPLORER_API_KEY: ${{ secrets.CORE_DAO_MAINNET_EXPLORER_API_KEY }}
+          FLARE_EXPLORER_API_KEY: ${{ secrets.FLARE_EXPLORER_API_KEY }}
+          SONGBIRD_EXPLORER_API_KEY: ${{ secrets.SONGBIRD_EXPLORER_API_KEY }}
+          XDC_EXPLORER_API_KEY: ${{ secrets.XDC_EXPLORER_API_KEY }}
+          WEMIX_EXPLORER_API_KEY: ${{ secrets.WEMIX_EXPLORER_API_KEY }}
+          BERA_RPC_URL: ${{ secrets.BERA_RPC_URL }}
+          HOODETH_RPC_URL: ${{ secrets.HOODETH_RPC_URL }}
+          MONAD_EXPLORER_API_KEY: ${{ secrets.MONAD_EXPLORER_API_KEY }}
+          SOMNIA_EXPLORER_API_KEY: ${{ secrets.SOMNIA_EXPLORER_API_KEY }}
+          SONEIUM_EXPLORER_API_KEY: ${{ secrets.SONEIUM_EXPLORER_API_KEY }}
+          WORLD_EXPLORER_API_KEY: ${{ secrets.WORLD_EXPLORER_API_KEY }}
+          CTC_EXPLORER_API_KEY: ${{ secrets.CTC_EXPLORER_API_KEY }}
+          PHAROS_EXPLORER_API_KEY: ${{ secrets.PHAROS_EXPLORER_API_KEY }}
+          HYPEEVM_EXPLORER_API_KEY: ${{ secrets.HYPEEVM_EXPLORER_API_KEY }}
+          SEIEVM_EXPLORER_API_KEY: ${{ secrets.SEIEVM_EXPLORER_API_KEY }}
+          KAIA_EXPLORER_API_KEY: ${{ secrets.KAIA_EXPLORER_API_KEY }}
+          IP_EXPLORER_API_KEY: ${{ secrets.IP_EXPLORER_API_KEY }}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "deploy-test": "hardhat run scripts/deploy.ts --network",
     "deploy-batcher": "hardhat run scripts/deployBatcherContract.ts --network",
     "update-gas-limit": "hardhat run scripts/updateTransferGasLimit.ts --network",
+    "transfer-batcher-ownership": "hardhat run scripts/transferBatcherOwnership.ts --network",
     "test": "hardhat test",
     "coverage": "hardhat coverage",
     "solhint": "./node_modules/.bin/solhint --fix 'contracts/**/*.sol'",

--- a/scripts/transferBatcherOwnership.ts
+++ b/scripts/transferBatcherOwnership.ts
@@ -1,0 +1,133 @@
+import { ethers } from 'hardhat';
+import { getChainConfig } from './chainConfig';
+import { logger } from '../deployUtils';
+
+// The Batcher owner is being migrated to a TSS custody wallet (COINS-1281).
+//
+// This constant is the sole source of truth for the new owner address. It
+// must only ever be set via a reviewed, merged PR -- never taken from a CLI
+// argument, an env var, or any other runtime input. It is cross-checked
+// against the BATCHER_NEW_OWNER_ADDRESS secret (set by DevOps once the
+// custody wallet is provisioned, see COINS-1280) before any transaction is
+// sent, so a disagreement between the two aborts the run instead of silently
+// transferring ownership to the wrong address.
+//
+// TODO(COINS-1280): fill in with the custody wallet's base address once
+// DevOps hands it back. Left empty until then so the script refuses to run.
+const NEW_OWNER_ADDRESS = '';
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+function isValidAddress(address: string): boolean {
+  return /^0x[0-9a-fA-F]{40}$/.test(address);
+}
+
+async function main() {
+  // Use the third configured signer on the selected network (same signer
+  // index as updateTransferGasLimit.ts and the deploy scripts --
+  // PRIVATE_KEY_FOR_BATCHER_CONTRACT_DEPLOYMENT).
+  const signers = await ethers.getSigners();
+  const signer = signers[2];
+  const from = await signer.getAddress();
+
+  const { chainId } = await ethers.provider.getNetwork();
+  const chainConfig = await getChainConfig(Number(chainId));
+  const gasOverrides = chainConfig?.gasParams ?? {};
+
+  // Required: BATCHER_ADDRESS env var
+  const batcherAddress = (process.env.BATCHER_ADDRESS || '').trim();
+  if (!isValidAddress(batcherAddress)) {
+    throw new Error(
+      'BATCHER_ADDRESS env var is required and must be a valid 0x-prefixed address'
+    );
+  }
+
+  const code = await ethers.provider.getCode(batcherAddress);
+  if (!code || code === '0x') {
+    throw new Error(
+      `No contract code at ${batcherAddress} on chainId ${chainId}. Check the address and network.`
+    );
+  }
+
+  // The new owner address must never come from user input -- see the
+  // comment on NEW_OWNER_ADDRESS above. Cross-check the reviewed constant
+  // against the DevOps-provided secret before doing anything else.
+  if (!isValidAddress(NEW_OWNER_ADDRESS)) {
+    throw new Error(
+      'NEW_OWNER_ADDRESS constant is not set. Fill it in with the custody ' +
+        'wallet base address (COINS-1280) via a reviewed PR before running ' +
+        'this script.'
+    );
+  }
+
+  if (NEW_OWNER_ADDRESS.toLowerCase() === ZERO_ADDRESS) {
+    throw new Error('NEW_OWNER_ADDRESS cannot be the zero address');
+  }
+
+  const secretAddress = (process.env.BATCHER_NEW_OWNER_ADDRESS || '').trim();
+  if (!secretAddress) {
+    throw new Error(
+      'BATCHER_NEW_OWNER_ADDRESS env var is required (set by DevOps once ' +
+        'the custody wallet is provisioned).'
+    );
+  }
+  if (!isValidAddress(secretAddress)) {
+    throw new Error(
+      `BATCHER_NEW_OWNER_ADDRESS is not a valid address: ${secretAddress}`
+    );
+  }
+  if (secretAddress.toLowerCase() !== NEW_OWNER_ADDRESS.toLowerCase()) {
+    throw new Error(
+      'New owner address mismatch -- aborting. ' +
+        `hardcoded=${NEW_OWNER_ADDRESS} secret=${secretAddress}. ` +
+        'These must match exactly before any transaction is sent.'
+    );
+  }
+
+  const batcher = await ethers.getContractAt('Batcher', batcherAddress, signer);
+
+  // Verify ownership (Ownable2Step) -- the caller must be the current owner.
+  const owner: string = await batcher.owner();
+  if (owner.toLowerCase() !== from.toLowerCase()) {
+    throw new Error(`Caller is not owner. Owner=${owner}, Caller=${from}`);
+  }
+
+  const currentPendingOwner: string = await batcher.pendingOwner();
+
+  logger.info(`Network: ${chainId}`);
+  logger.info(`Batcher: ${batcherAddress}`);
+  logger.info(`Caller:  ${from}`);
+  logger.info(`Current owner():        ${owner}`);
+  logger.info(`Current pendingOwner(): ${currentPendingOwner}`);
+  logger.info(`New pendingOwner:       ${NEW_OWNER_ADDRESS}`);
+
+  if (currentPendingOwner.toLowerCase() === NEW_OWNER_ADDRESS.toLowerCase()) {
+    logger.warn(
+      'pendingOwner() already equals the intended new owner. Re-sending ' +
+        'is harmless (transferOwnership replaces the pending transfer) but ' +
+        'unnecessary.'
+    );
+  }
+
+  const tx = await batcher.transferOwnership(NEW_OWNER_ADDRESS, {
+    ...gasOverrides
+  });
+  logger.info(`Tx sent: ${tx.hash}`);
+  const rc = await tx.wait();
+  logger.success(`Mined in block: ${rc.blockNumber}`);
+
+  const updatedPendingOwner: string = await batcher.pendingOwner();
+  if (updatedPendingOwner.toLowerCase() !== NEW_OWNER_ADDRESS.toLowerCase()) {
+    throw new Error(
+      `Post-send verification failed: pendingOwner()=${updatedPendingOwner}, ` +
+        `expected ${NEW_OWNER_ADDRESS}. Do not proceed to acceptOwnership().`
+    );
+  }
+  logger.success(`pendingOwner() confirmed: ${updatedPendingOwner}`);
+  logger.success('Done ✅');
+}
+
+main().catch((err) => {
+  logger.error(`Failed: ${err}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds `scripts/transferBatcherOwnership.ts` + `.github/workflows/transfer_batcher_ownership.yaml`, sending step 1 of the `Ownable2Step` handover (`transferOwnership(newOwner)`) as part of moving Batcher ownership to a TSS custody wallet.
- Modeled directly on the existing `updateTransferGasLimit.ts` / `update_transfer_gas_limit.yaml` pair: same two-job `preview` → environment-gated `run-transfer` structure, same signer (index 2, `PRIVATE_KEY_FOR_BATCHER_CONTRACT_DEPLOYMENT`), same env-var wiring.
- The new owner address is **not** a workflow input. Per design, it's a hardcoded constant (`NEW_OWNER_ADDRESS` in the script) set via reviewed PR, cross-checked at runtime against a `BATCHER_NEW_OWNER_ADDRESS` secret — the script aborts on any mismatch.

## Why draft
`NEW_OWNER_ADDRESS` is intentionally **left blank**. DevOps is provisioning the TSS custody wallet ([COINS-1280](https://linear.app/bitgo/issue/COINS-1280)); once they hand back the base address and add it to the `BATCHER_NEW_OWNER_ADDRESS` GitHub secret, I'll fill in the constant, un-draft, and this is ready for review/merge.

## Pre-flight / post-send checks in the script
- Contract code exists at the target Batcher address
- `owner()` == the signing key's address
- `NEW_OWNER_ADDRESS` constant is set and matches `BATCHER_NEW_OWNER_ADDRESS` exactly
- Target is a valid, non-zero address
- After sending: reads back `pendingOwner()` and asserts it matches — this step is reversible (re-issuing `transferOwnership` replaces the pending transfer); only the subsequent `acceptOwnership()` (separate ticket, [COINS-1282](https://linear.app/bitgo/issue/COINS-1282)) is not.

## Test plan
- [x] `npx tsc --noEmit` — no new type errors (pre-existing unrelated `ignition-core` `.d.ts` errors confirmed present on `master` too)
- [x] `npx prettier --check` on changed files — passes
- [x] Workflow YAML validated (parses correctly, `workflow_dispatch` inputs/jobs as expected)
- [x] `npx hardhat test test/batcher.js` — pre-existing `HH8` config error reproduced identically on unmodified `master` (missing local `.env` secrets in this environment), confirmed unrelated to this change
- [ ] Fill in `NEW_OWNER_ADDRESS` once DevOps provisions the wallet (COINS-1280)
- [ ] Run against `tmorpheth` (testnet) manually via `workflow_dispatch`, verify `pendingOwner()` on-chain
- [ ] Testnet validation gate ([COINS-1318](https://linear.app/bitgo/issue/COINS-1318)) before any mainnet run

Ref: [TDD §6](https://linear.app/bitgo/document/tdd-batcher-ownership-migration-to-tss-custody-wallet-6e34c92f1e42)

🤖 Generated with [Claude Code](https://claude.com/claude-code)